### PR TITLE
- Fix: Buttons showing cart subtotal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 ## Changelog ##
+### 1.5.6 ###
+- Fix: Buttons showing cart subtotal.
+
 ### 1.5.5 ###
 - Improvement: Compatibility with Elementor v3.1.
 - Improvement: Cart - Added Items Count hover color options.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.4  
 **Requires PHP:** 5.4  
 **Tested up to:** 5.6  
-**Stable tag:** 1.5.5  
+**Stable tag:** 1.5.6  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 1.5.5
+ * Version: 1.5.6
  * Elementor tested up to: 3.1.0
  * Elementor Pro tested up to: 3.0.9
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.5.5' );
+define( 'HFE_VER', '1.5.6' );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );
 define( 'HFE_PATH', plugin_basename( __FILE__ ) );

--- a/inc/widgets-manager/class-widgets-loader.php
+++ b/inc/widgets-manager/class-widgets-loader.php
@@ -217,7 +217,7 @@ class Widgets_Loader {
 
 			$fragments['span.hfe-cart-count'] = '<span class="hfe-cart-count">' . WC()->cart->get_cart_contents_count() . '</span>';
 
-			$fragments['span.elementor-button-text'] = '<span class="elementor-button-text">' . WC()->cart->get_cart_subtotal() . '</span>';
+			$fragments['span.elementor-button-text.hfe-subtotal'] = '<span class="elementor-button-text hfe-subtotal">' . WC()->cart->get_cart_subtotal() . '</span>';
 		}
 
 		$fragments['span.elementor-button-icon[data-counter]'] = '<span class="elementor-button-icon" data-counter="' . $cart_badge_count . '"><i class="eicon" aria-hidden="true"></i><span class="elementor-screen-only">' . __( 'Cart', 'header-footer-elementor' ) . '</span></span>';

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -640,7 +640,7 @@ class Cart extends Widget_Base {
 					<div class="hfe-menu-cart__toggle elementor-button-wrapper">
 						<a id="hfe-menu-cart__toggle_button" href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="elementor-button hfe-cart-container">
 							<?php if ( null !== WC()->cart ) { ?>
-								<span class="elementor-button-text">
+								<span class="elementor-button-text hfe-subtotal">
 									<?php echo WC()->cart->get_cart_subtotal(); ?>
 								</span>
 							<?php } ?>

--- a/languages/header-footer-elementor.pot
+++ b/languages/header-footer-elementor.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Elementor - Header, Footer & Blocks package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Elementor - Header, Footer & Blocks 1.5.5\n"
+"Project-Id-Version: Elementor - Header, Footer & Blocks 1.5.6\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/header-footer-elementor\n"
-"POT-Creation-Date: 2021-01-18 12:29:31+00:00\n"
+"POT-Creation-Date: 2021-01-19 10:35:45+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
 Tested up to: 5.6
-Stable tag: 1.5.5
+Stable tag: 1.5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 == Changelog ==
+= 1.5.6 =
+- Fix: Buttons showing cart subtotal.
+
 = 1.5.5 =
 - Improvement: Compatibility with Elementor v3.1.
 - Improvement: Cart - Added Items Count hover color options.


### PR DESCRIPTION
### Description
Due to a common fragments class, buttons were showing cart subtotal

### Types of changes
 Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Checked the working of widget and fix

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] I've added proper labels to this pull request
