### PR TITLE
Improvement: Added Elementor v3.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.4  
 **Requires PHP:** 5.4  
 **Tested up to:** 5.6  
-**Stable tag:** 1.5.6  
+**Stable tag:** 1.5.7
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 ## Changelog ##
+### 1.5.7 ###
+- Improvement: Compatibility to Elementor v3.1.
+
 ### 1.5.6 ###
 - Fix: Buttons showing cart subtotal.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Requires at least:** 4.4  
 **Requires PHP:** 5.4  
-**Tested up to:** 5.6  
+**Tested up to:** 5.7 
 **Stable tag:** 1.5.7
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -8,8 +8,8 @@
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
  * Version: 1.5.6
- * Elementor tested up to: 3.1.0
- * Elementor Pro tested up to: 3.0.9
+ * Elementor tested up to: 3.1.3
+ * Elementor Pro tested up to: 3.1.1
  *
  * @package         header-footer-elementor
  */

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 1.5.6
+ * Version: 1.5.7
  * Elementor tested up to: 3.1.3
  * Elementor Pro tested up to: 3.1.1
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.5.6' );
+define( 'HFE_VER', '1.5.7' );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );
 define( 'HFE_PATH', plugin_basename( __FILE__ ) );

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -90,7 +90,7 @@ class Cart extends Widget_Base {
 	 * @since 1.4.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->register_general_content_controls();
 		$this->register_cart_typo_content_controls();

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -85,9 +85,20 @@ class Cart extends Widget_Base {
 	}
 
 	/**
-	 * Register cart controls controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.4.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+ 
+	/**
+	 * Register cart controls controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -85,7 +85,7 @@ class Cart extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register cart controls.
 	 *
 	 * @since 1.4.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -96,7 +96,7 @@ class Cart extends Widget_Base {
 	}
 
 	/**
-	 * Register cart controls controls.
+	 * Register cart controls.
 	 *
 	 * @since x.x.x
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -94,7 +94,7 @@ class Cart extends Widget_Base {
 
 		$this->register_controls();
 	}
- 
+
 	/**
 	 * Register cart controls controls.
 	 *

--- a/inc/widgets-manager/widgets/class-copyright.php
+++ b/inc/widgets-manager/widgets/class-copyright.php
@@ -86,7 +86,7 @@ class Copyright extends Widget_Base {
 	 * @since 1.2.0
 	 * @access protected
 	 */
-	protected function _register_controls() { //phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+	protected function register_controls() { //phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 		$this->register_content_copy_right_controls();
 	}
 	/**

--- a/inc/widgets-manager/widgets/class-copyright.php
+++ b/inc/widgets-manager/widgets/class-copyright.php
@@ -86,7 +86,7 @@ class Copyright extends Widget_Base {
 	 * @since 1.2.0
 	 * @access protected
 	 */
-	protected function register_controls() { //phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+	protected function register_controls() {
 		$this->register_content_copy_right_controls();
 	}
 	/**

--- a/inc/widgets-manager/widgets/class-copyright.php
+++ b/inc/widgets-manager/widgets/class-copyright.php
@@ -82,7 +82,7 @@ class Copyright extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register Copyright controls.
 	 *
 	 * @since 1.2.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-copyright.php
+++ b/inc/widgets-manager/widgets/class-copyright.php
@@ -80,10 +80,22 @@ class Copyright extends Widget_Base {
 	public function get_categories() {
 		return [ 'hfe-widgets' ];
 	}
+
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 1.2.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
 	/**
 	 * Register Copyright controls.
 	 *
-	 * @since 1.2.0
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -161,7 +161,7 @@ class Navigation_Menu extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register Nav Menu controls.
 	 *
 	 * @since 1.3.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -160,11 +160,21 @@ class Navigation_Menu extends Widget_Base {
 		}
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 1.3.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
 
 	/**
 	 * Register Nav Menu controls.
 	 *
-	 * @since 1.3.0
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -167,7 +167,7 @@ class Navigation_Menu extends Widget_Base {
 	 * @since 1.3.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->register_general_content_controls();
 		$this->register_style_content_controls();

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -86,9 +86,20 @@ class Page_Title extends Widget_Base {
 	}
 
 	/**
-	 * Register Page Title controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.3.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
+	/**
+	 * Register Page Title controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -86,7 +86,7 @@ class Page_Title extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register Page Title controls.
 	 *
 	 * @since 1.3.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -92,7 +92,6 @@ class Page_Title extends Widget_Base {
 	 * @access protected
 	 */
 	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-
 		$this->register_controls();
 	}
 

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -91,7 +91,7 @@ class Page_Title extends Widget_Base {
 	 * @since 1.3.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$this->register_content_page_title_controls();
 		$this->register_page_title_style_controls();
 	}

--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -96,7 +96,7 @@ class Retina extends Widget_Base {
 	 * @since 1.2.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$this->register_content_retina_image_controls();
 		$this->register_retina_image_styling_controls();
 		$this->register_retina_caption_styling_controls();

--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -91,7 +91,7 @@ class Retina extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register Retina Logo controls.
 	 *
 	 * @since 1.2.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -91,9 +91,20 @@ class Retina extends Widget_Base {
 	}
 
 	/**
-	 * Register Retina Logo controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.2.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
+	/**
+	 * Register Retina Logo controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -100,9 +100,20 @@ class Search_Button extends Widget_Base {
 	}
 
 	/**
-	 * Register Search Button controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.5.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
+	/**
+	 * Register Search Button controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -100,7 +100,7 @@ class Search_Button extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register Search Button controls.
 	 *
 	 * @since 1.5.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -105,7 +105,7 @@ class Search_Button extends Widget_Base {
 	 * @since 1.5.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$this->register_general_content_controls();
 		$this->register_search_style_controls();
 	}

--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -93,7 +93,7 @@ class Site_Logo extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register Site Logo controls.
 	 *
 	 * @since 1.3.0
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -93,9 +93,20 @@ class Site_Logo extends Widget_Base {
 	}
 
 	/**
-	 * Register Site Logo controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.3.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
+	/**
+	 * Register Site Logo controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -98,7 +98,7 @@ class Site_Logo extends Widget_Base {
 	 * @since 1.3.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$this->register_content_site_logo_controls();
 		$this->register_site_logo_styling_controls();
 		$this->register_site_logo_caption_styling_controls();

--- a/inc/widgets-manager/widgets/class-site-tagline.php
+++ b/inc/widgets-manager/widgets/class-site-tagline.php
@@ -85,7 +85,7 @@ class Site_Tagline extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register site tagline controls.
 	 *
 	 * @since 1.3.0
 	 * @access protected
@@ -96,7 +96,7 @@ class Site_Tagline extends Widget_Base {
 	}
 
 	/**
-	 * Register site tagline controls controls.
+	 * Register site tagline controls.
 	 *
 	 * @since x.x.x
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-site-tagline.php
+++ b/inc/widgets-manager/widgets/class-site-tagline.php
@@ -85,9 +85,20 @@ class Site_Tagline extends Widget_Base {
 	}
 
 	/**
-	 * Register site tagline controls controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.3.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
+	/**
+	 * Register site tagline controls controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-site-tagline.php
+++ b/inc/widgets-manager/widgets/class-site-tagline.php
@@ -90,7 +90,7 @@ class Site_Tagline extends Widget_Base {
 	 * @since 1.3.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$this->register_general_content_controls();
 	}
 

--- a/inc/widgets-manager/widgets/class-site-title.php
+++ b/inc/widgets-manager/widgets/class-site-title.php
@@ -85,9 +85,20 @@ class Site_Title extends Widget_Base {
 	}
 
 	/**
-	 * Register site title controls controls.
+	 * Register widget controls.
 	 *
 	 * @since 1.3.0
+	 * @access protected
+	 */
+	protected function _register_controls() { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+
+		$this->register_controls();
+	}
+
+	/**
+	 * Register site title controls controls.
+	 *
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_controls() {

--- a/inc/widgets-manager/widgets/class-site-title.php
+++ b/inc/widgets-manager/widgets/class-site-title.php
@@ -85,7 +85,7 @@ class Site_Title extends Widget_Base {
 	}
 
 	/**
-	 * Register widget controls.
+	 * Register site title controls.
 	 *
 	 * @since 1.3.0
 	 * @access protected
@@ -96,7 +96,7 @@ class Site_Title extends Widget_Base {
 	}
 
 	/**
-	 * Register site title controls controls.
+	 * Register site title controls.
 	 *
 	 * @since x.x.x
 	 * @access protected

--- a/inc/widgets-manager/widgets/class-site-title.php
+++ b/inc/widgets-manager/widgets/class-site-title.php
@@ -90,7 +90,7 @@ class Site_Title extends Widget_Base {
 	 * @since 1.3.0
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		$this->register_general_content_controls();
 		$this->register_heading_typo_content_controls();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: elementor, header footer builder, header template, footer template, elemen
 Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
-Tested up to: 5.6
-Stable tag: 1.5.6
+Tested up to: 5.7
+Stable tag: 1.5.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 == Changelog ==
+= 1.5.7 =
+- Improvement: Compatibility to Elementor v3.1.
+
 = 1.5.6 =
 - Fix: Buttons showing cart subtotal.
 


### PR DESCRIPTION
### Description
_register_controls method deprecated with Elementor v3.1. Added compatibility to this.
Updated the Stable and tested up to tags.
Related Task link - https://trello.com/c/cYInFGDG/91-elementor-31-compatibility-testing

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Imporovement (non-breaking change which adds functionality) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Drag-drop all the widgets on the page. Make sure the widgets work properly.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
