### PR TITLE
Fix: Undefined index notice when menu is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 ### 1.5.7 ###
 - Improvement: Compatibility to Elementor v3.1.
+- Fix: Navigation Menu - Undefined index notice when menu is not set.
 
 ### 1.5.6 ###
 - Fix: Buttons showing cart subtotal.

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1862,7 +1862,14 @@ class Navigation_Menu extends Widget_Base {
 	 */
 	protected function render() {
 
+		$menus = $this->get_available_menus();
+
+		if ( empty( $menus ) ) {
+			return false;
+		}
+
 		$settings         = $this->get_settings_for_display();
+
 		$menu_close_icons = [];
 		$menu_close_icons = $this->get_menu_close_icon( $settings );
 

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1868,7 +1868,7 @@ class Navigation_Menu extends Widget_Base {
 			return false;
 		}
 
-		$settings         = $this->get_settings_for_display();
+		$settings = $this->get_settings_for_display();
 
 		$menu_close_icons = [];
 		$menu_close_icons = $this->get_menu_close_icon( $settings );


### PR DESCRIPTION
### Description
Fixed the undefined index notice when the menu is not set from menu dashboard settings.
PHP Notice:  Undefined index: menu in /home3/mydomain9/akshaylakhara.mydomain9.com/wp-content/plugins/header-footer-elementor-next-release/inc/widgets-manager/widgets/class-navigation-menu.php on line 1871

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Do not create a menu on your site. - https://share.getcloudapp.com/DOu2yYbR
Build an HFE header template.
Drag Drop the menu widget on the page.
The notice will appear in console.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
