### PR TITLE
Security: Fix - Vulnerability in HTML tags

### DIFF
--- a/inc/widgets-manager/class-widgets-loader.php
+++ b/inc/widgets-manager/class-widgets-loader.php
@@ -12,6 +12,7 @@
 namespace HFE\WidgetsManager;
 
 use Elementor\Plugin;
+use Elementor\Utils;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -19,6 +20,28 @@ defined( 'ABSPATH' ) or exit;
  * Set up Widgets Loader class
  */
 class Widgets_Loader {
+
+	/**
+	 * A list of safe tage for `validate_html_tag` method.
+	 */
+	const ALLOWED_HTML_WRAPPER_TAGS = [
+		'article',
+		'aside',
+		'div',
+		'footer',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'header',
+		'main',
+		'nav',
+		'p',
+		'section',
+		'span',
+	];
 
 	/**
 	 * Instance of Widgets_Loader.
@@ -223,6 +246,22 @@ class Widgets_Loader {
 		$fragments['span.elementor-button-icon[data-counter]'] = '<span class="elementor-button-icon" data-counter="' . $cart_badge_count . '"><i class="eicon" aria-hidden="true"></i><span class="elementor-screen-only">' . __( 'Cart', 'header-footer-elementor' ) . '</span></span>';
 
 		return $fragments;
+	}
+
+	/**
+	 * Validate an HTML tag against a safe allowed list.
+	 *
+	 * @since x.x.x
+	 * @param string $tag
+	 *
+	 * @return string
+	 */
+	public static function validate_html_tag( $tag ) {
+		if( method_exists( 'Elementor\Utils', 'validate_html_tag' ) ) {
+			return Utils::validate_html_tag( $tag );
+		} else {
+			return in_array( strtolower( $tag ), self::ALLOWED_HTML_WRAPPER_TAGS ) ? $tag : 'div';
+		}
 	}
 }
 

--- a/inc/widgets-manager/class-widgets-loader.php
+++ b/inc/widgets-manager/class-widgets-loader.php
@@ -22,28 +22,6 @@ defined( 'ABSPATH' ) or exit;
 class Widgets_Loader {
 
 	/**
-	 * A list of safe tage for `validate_html_tag` method.
-	 */
-	const ALLOWED_HTML_WRAPPER_TAGS = [
-		'article',
-		'aside',
-		'div',
-		'footer',
-		'h1',
-		'h2',
-		'h3',
-		'h4',
-		'h5',
-		'h6',
-		'header',
-		'main',
-		'nav',
-		'p',
-		'section',
-		'span',
-	];
-
-	/**
 	 * Instance of Widgets_Loader.
 	 *
 	 * @since  1.2.0
@@ -252,15 +230,18 @@ class Widgets_Loader {
 	 * Validate an HTML tag against a safe allowed list.
 	 *
 	 * @since x.x.x
-	 * @param string $tag
-	 *
-	 * @return string
+	 * @param string $tag specifies the HTML Tag.
+	 * @access public
 	 */
 	public static function validate_html_tag( $tag ) {
-		if( method_exists( 'Elementor\Utils', 'validate_html_tag' ) ) {
+
+		// Check if Elementor method exists, else we will run custom validation code.
+		if ( method_exists( 'Elementor\Utils', 'validate_html_tag' ) ) {
 			return Utils::validate_html_tag( $tag );
 		} else {
-			return in_array( strtolower( $tag ), self::ALLOWED_HTML_WRAPPER_TAGS ) ? $tag : 'div';
+
+			$allowed_tags = [ 'article', 'aside', 'div', 'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'main', 'nav', 'p', 'section', 'span' ];
+			return in_array( strtolower( $tag ), $allowed_tags ) ? $tag : 'div';
 		}
 	}
 }

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -14,6 +14,8 @@ use Elementor\Group_Control_Typography;
 use Elementor\Scheme_Typography;
 use Elementor\Scheme_Color;
 
+use HFE\WidgetsManager\Widgets_Loader;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
 }
@@ -430,6 +432,8 @@ class Page_Title extends Widget_Base {
 			}
 			$link = $this->get_render_attribute_string( 'url' );
 		}
+
+		$heading_size = Widgets_Loader::validate_html_tag( $settings['heading_tag'] );
 		?>		
 		<div class="hfe-page-title hfe-page-title-wrapper elementor-widget-heading">
 
@@ -442,7 +446,7 @@ class Page_Title extends Widget_Base {
 			<?php } elseif ( 'default' === $head_custom_link ) { ?>
 						<a href="<?php echo esc_url( get_home_url() ); ?>">
 			<?php } ?>
-			<<?php echo wp_kses_post( $settings['heading_tag'] ); ?> class="elementor-heading-title elementor-size-<?php echo $settings['size']; ?>">
+			<<?php echo $heading_size; ?> class="elementor-heading-title elementor-size-<?php echo $settings['size']; ?>">
 				<?php if ( '' !== $settings['new_page_title_select_icon']['value'] ) { ?>
 						<span class="hfe-page-title-icon">
 							<?php \Elementor\Icons_Manager::render_icon( $settings['new_page_title_select_icon'], [ 'aria-hidden' => 'true' ] ); ?>             </span>
@@ -462,7 +466,7 @@ class Page_Title extends Widget_Base {
 					?>
 					<?php echo wp_kses_post( $settings['after'] ); ?>
 				<?php } ?>  
-			</<?php echo wp_kses_post( $settings['heading_tag'] ); ?> > 
+			</<?php echo $heading_size; ?> > 
 			<?php if ( ( '' != $head_link_url && 'custom' === $head_custom_link ) || 'default' === $head_custom_link ) { ?>
 						</a>
 			<?php } ?>
@@ -491,12 +495,19 @@ class Page_Title extends Widget_Base {
 			view.addRenderAttribute( 'url', 'href', settings.page_heading_link.url );
 		}
 		var iconHTML = elementor.helpers.renderIcon( view, settings.new_page_title_select_icon, { 'aria-hidden': true }, 'i' , 'object' );
+
+		var headingSizeTag = settings.heading_tag;
+
+		if ( typeof elementor.helpers.validateHTMLTag === "function" ) { 
+			headingSizeTag = elementor.helpers.validateHTMLTag( settings.heading_tag );
+		}
+
 		#>
 		<div class="hfe-page-title hfe-page-title-wrapper elementor-widget-heading">
 			<# if ( '' != settings.page_heading_link.url ) { #>
 					<a {{{ view.getRenderAttributeString( 'url' ) }}} >
 			<# } #>
-			<{{{ settings.heading_tag }}} class="elementor-heading-title elementor-size-{{{ settings.size }}}">		
+			<{{{ headingSizeTag }}} class="elementor-heading-title elementor-size-{{{ settings.size }}}">		
 				<# if( '' != settings.new_page_title_select_icon.value ){ #>
 					<span class="hfe-page-title-icon" data-elementor-setting-key="page_title" data-elementor-inline-editing-toolbar="basic">
 						{{{iconHTML.value}}}                    
@@ -515,7 +526,7 @@ class Page_Title extends Widget_Base {
 					<# if ( '' != settings.after ) { #>
 						{{{ settings.after }}}
 					<# } #>				
-			</{{{ settings.heading_tag }}}>
+			</{{{ headingSizeTag }}}>
 			<# if ( '' != settings.page_heading_link.url ) { #>
 					</a>
 			<# } #>			

--- a/inc/widgets-manager/widgets/class-site-title.php
+++ b/inc/widgets-manager/widgets/class-site-title.php
@@ -13,6 +13,9 @@ use Elementor\Scheme_Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Scheme_Color;
+use Elementor\Utils;
+
+use HFE\WidgetsManager\Widgets_Loader;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -423,6 +426,8 @@ class Site_Title extends Widget_Base {
 			}
 			$link = $this->get_render_attribute_string( 'url' );
 		}
+
+		$heading_size = Widgets_Loader::validate_html_tag( $settings['heading_tag'] );
 		?>
 
 		<div class="hfe-module-content hfe-heading-wrapper elementor-widget-heading">
@@ -431,7 +436,7 @@ class Site_Title extends Widget_Base {
 				<?php } else { ?>
 					<a href="<?php echo get_home_url(); ?>">
 				<?php } ?>
-			<<?php echo wp_kses_post( $settings['heading_tag'] ); ?> class="hfe-heading elementor-heading-title elementor-size-<?php echo $settings['size']; ?>">
+			<<?php echo $heading_size; ?> class="hfe-heading elementor-heading-title elementor-size-<?php echo $settings['size']; ?>">
 				<?php if ( '' !== $settings['icon']['value'] ) { ?>
 					<span class="hfe-icon">
 						<?php \Elementor\Icons_Manager::render_icon( $settings['icon'], [ 'aria-hidden' => 'true' ] ); ?>					
@@ -450,7 +455,7 @@ class Site_Title extends Widget_Base {
 					}
 					?>
 					</span>			
-			</<?php echo wp_kses_post( $settings['heading_tag'] ); ?>>
+			</<?php echo $heading_size; ?>>
 			</a>		
 		</div>
 		<?php
@@ -476,15 +481,22 @@ class Site_Title extends Widget_Base {
 			view.addRenderAttribute( 'url', 'href', settings.heading_link.url );
 		}
 		var iconHTML = elementor.helpers.renderIcon( view, settings.icon, { 'aria-hidden': true }, 'i' , 'object' );
+
+		var headingSizeTag = settings.heading_tag;
+
+		if ( typeof elementor.helpers.validateHTMLTag === "function" ) { 
+			headingSizeTag = elementor.helpers.validateHTMLTag( settings.heading_tag );
+		}
+
 		#>
 		<div class="hfe-module-content hfe-heading-wrapper elementor-widget-heading">
 				<# if ( '' != settings.heading_link.url ) { #>
 					<a {{{ view.getRenderAttributeString( 'url' ) }}} >
 				<# } #>
-				<{{{ settings.heading_tag }}} class="hfe-heading elementor-heading-title elementor-size-{{{ settings.size }}}">
+				<{{{ headingSizeTag }}} class="hfe-heading elementor-heading-title elementor-size-{{{ settings.size }}}">
 				<# if( '' != settings.icon.value ){ #>
 				<span class="hfe-icon">
-					{{{iconHTML.value}}}					
+					{{{ iconHTML.value }}}					
 				</span>
 				<# } #>
 				<span class="hfe-heading-text  elementor-heading-title" data-elementor-setting-key="heading_title" data-elementor-inline-editing-toolbar="basic" >
@@ -496,7 +508,7 @@ class Site_Title extends Widget_Base {
 					{{{ settings.after }}}
 				<#}#>
 				</span>
-			</{{{ settings.heading_tag }}}>
+			</{{{ headingSizeTag }}}>
 			<# if ( '' != settings.heading_link.url ) { #>
 				</a>
 			<# } #>


### PR DESCRIPTION
### Description
Passing the user input like HTML_Tag directly to the HTML can be vulnerable if the script is passed through the tag!

### Screenshots
N/A

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Widgets - Site Title & Page Title
Issue with - Heading tag option like h1,h2, h3, etc.
Test Cases - 
- Check with Elementor v1.3.4 if the Heading tag is working fine.
- Revert to Elementor version 3.1.1 and check the same on the frontend and editor.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
