### PR TITLE
Feat: Added an option to hide + & - sign added by Twenty Twenty-One Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 ## Changelog ##
-### 1.5.9.1 ###
+### 1.5.10 ###
+- Improvement: Added an option to hide + & - sign added by Twenty Twenty-One Theme.
 - Fix: Navigation Menu - Top distance option for dropdown adding a top margin to sub-menu.
 
 ### 1.5.9 ###

--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -363,18 +363,18 @@
 						}	
 					
 						$this.removeClass( 'sub-menu-active' );
-						$this.next().removeClass( 'sub-menu-open' );
-						$this.next().css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
-						$this.next().css( { 'transition': 'none'} );										
+						$this.nextAll('.sub-menu').removeClass( 'sub-menu-open' );
+						$this.nextAll('.sub-menu').css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
+						$this.nextAll('.sub-menu').css( { 'transition': 'none'} );
 					} else{
 
 						$this.find( 'a' ).attr( 'aria-expanded', 'false' );
 						
 						$this.removeClass( 'sub-menu-active' );
-						$this.next().removeClass( 'sub-menu-open' );
-						$this.next().css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
-						$this.next().css( { 'transition': 'none'} );	
-													
+						$this.nextAll('.sub-menu').removeClass( 'sub-menu-open' );
+						$this.nextAll('.sub-menu').css( { 'visibility': 'hidden', 'opacity': '0', 'height': '0' } );
+						$this.nextAll('.sub-menu').css( { 'transition': 'none'} );
+
 						if ( 'horizontal' !== layout ){
 
 							$this.next().css( 'position', 'relative' );
@@ -411,9 +411,9 @@
 					}	
 							
 					$this.addClass( 'sub-menu-active' );
-					$this.next().addClass( 'sub-menu-open' );	
-					$this.next().css( { 'visibility': 'visible', 'opacity': '1', 'height': 'auto' } );
-					$this.next().css( { 'transition': '0.3s ease'} );								
+					$this.nextAll('.sub-menu').addClass( 'sub-menu-open' );
+					$this.nextAll('.sub-menu').css( { 'visibility': 'visible', 'opacity': '1', 'height': 'auto' } );
+					$this.nextAll('.sub-menu').css( { 'transition': '0.3s ease'} );
 				}
 			}
 		});

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -21,7 +21,9 @@ ul.hfe-nav-menu,
     position: relative;
     background: inherit;
 }
-
+.hfe-nav-menu__theme-icon-yes button.sub-menu-toggle {
+    display: none;
+}
 div.hfe-nav-menu,
 .elementor-widget-hfe-nav-menu .elementor-widget-container {
     -js-display: flex;

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -255,7 +255,7 @@ class Navigation_Menu extends Widget_Base {
 		);
 
 		$current_theme = wp_get_theme();
-		
+
 		if ( 'Twenty Twenty-One' === $current_theme->get( 'Name' ) ) {
 			$this->add_control(
 				'hide_theme_icons',

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -254,6 +254,23 @@ class Navigation_Menu extends Widget_Base {
 			]
 		);
 
+		$current_theme = wp_get_theme();
+		
+		if ( 'Twenty Twenty-One' === $current_theme->get( 'Name' ) ) {
+			$this->add_control(
+				'hide_theme_icons',
+				[
+					'label'        => __( 'Hide + & - Sign', 'header-footer-elementor' ),
+					'type'         => Controls_Manager::SWITCHER,
+					'label_on'     => __( 'Yes', 'header-footer-elementor' ),
+					'label_off'    => __( 'No', 'header-footer-elementor' ),
+					'return_value' => 'yes',
+					'default'      => 'no',
+					'prefix_class' => 'hfe-nav-menu__theme-icon-',
+				]
+			);
+		}
+
 		$this->end_controls_section();
 
 			$this->start_controls_section(

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.5.8 =
+- Improvement: Added an option to hide + & - sign added by Twenty Twenty-One Theme.
+
+= 1.5.8 =
 - Fix: Hardened allowed options in the editor to enforce better security policies.
 
 = 1.5.7 =


### PR DESCRIPTION
### Description
Twenty Twenty-One theme adds + & - sign for expandable menu

### Screenshots
Problem Statement - https://a.cl.ly/KouZgOll

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Improvement

### How has this been tested?
- Install and activate the 2021 theme.
- Use Navigation Menu on Page

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
