### PR TITLE
Chore: Version 1.5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ This same applies when you are creating your Header/Footer using this plugin.
 ### 1.5.9 ###
 - Improvement: Added notice to update Elementor to v3.0.0 or higher
 Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 
-- Improvement: Added notice to update the Elementor version to 3.0.0 or higher.
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 - Fix: Navigation Menu - Last menu item button alignment not working in RTL view.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 ### 1.5.9 ###
-- Improvement: Added Elementor Global Color and Typography scheme support.
+- Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 
 ### 1.5.8 ###

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.4  
 **Requires PHP:** 5.4  
 **Tested up to:** 5.7  
-**Stable tag:** 1.5.8  
+**Stable tag:** 1.5.9  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 ### 1.5.9 ###
+- Improvement: Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 
 ### 1.5.8 ###

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 ## Changelog ##
+### 1.5.9 ###
+- Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
+
 ### 1.5.8 ###
 - Fix: Hardened allowed options in the editor to enforce better security policies.
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,10 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 ### 1.5.9 ###
+- Improvement: Added notice to update the Elementor version to 3.0.0 or higher.
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
+- Fix: Navigation Menu - Last menu item button alignment not working in RTL view.
 
 ### 1.5.8 ###
 - Fix: Hardened allowed options in the editor to enforce better security policies.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 ### 1.5.9 ###
+- Improvement: Added notice to update Elementor to v3.0.0 or higher
+Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 
 - Improvement: Added notice to update the Elementor version to 3.0.0 or higher.
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -8,8 +8,8 @@
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
  * Version: 1.5.8
- * Elementor tested up to: 3.1.3
- * Elementor Pro tested up to: 3.1.1
+ * Elementor tested up to: 3.2
+ * Elementor Pro tested up to: 3.2
  *
  * @package         header-footer-elementor
  */

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 1.5.8
+ * Version: 1.5.9
  * Elementor tested up to: 3.2
  * Elementor Pro tested up to: 3.2
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.5.8' );
+define( 'HFE_VER', '1.5.9' );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );
 define( 'HFE_PATH', plugin_basename( __FILE__ ) );

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -270,7 +270,7 @@ class Header_Footer_Elementor {
 		if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
 
 			$action_url   = wp_nonce_url( self_admin_url ( 'update.php?action=upgrade-plugin&amp;plugin=' ) . $plugin . '&amp;', 'upgrade-plugin_' . $plugin );
-			$button_label = __( 'Update Elementor Now', 'header-footer-elementor' );
+			$button_label = __( 'Update Elementor', 'header-footer-elementor' );
 
 		} else {
 

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -269,7 +269,7 @@ class Header_Footer_Elementor {
 
 		if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
 
-			$action_url   = wp_nonce_url( self_admin_url ( 'update.php?action=upgrade-plugin&amp;plugin=' ) . $plugin . '&amp;', 'upgrade-plugin_' . $plugin );
+			$action_url   = wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&amp;plugin=' ) . $plugin . '&amp;', 'upgrade-plugin_' . $plugin );
 			$button_label = __( 'Update Elementor', 'header-footer-elementor' );
 
 		} else {

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -51,7 +51,17 @@ class Header_Footer_Elementor {
 	function __construct() {
 		$this->template = get_template();
 
-		if ( defined( 'ELEMENTOR_VERSION' ) && is_callable( 'Elementor\Plugin::instance' ) ) {
+		$is_elementor_callable = ( defined( 'ELEMENTOR_VERSION' ) && is_callable( 'Elementor\Plugin::instance' ) ) ? true : false;
+
+		$required_elementor_version = '3.0.0';
+
+		$is_elementor_outdated = ( $is_elementor_callable && ( ! version_compare( ELEMENTOR_VERSION, $required_elementor_version, '>=' ) ) ) ? true : false;
+
+		if ( ( ! $is_elementor_callable ) || $is_elementor_outdated ) {
+			$this->elementor_not_available( $is_elementor_callable, $is_elementor_outdated );
+		}
+
+		if ( $is_elementor_callable ) {
 			self::$elementor_instance = Elementor\Plugin::instance();
 
 			$this->includes();
@@ -107,9 +117,6 @@ class Header_Footer_Elementor {
 				]
 			);
 
-		} else {
-			add_action( 'admin_notices', [ $this, 'elementor_not_available' ] );
-			add_action( 'network_admin_notices', [ $this, 'elementor_not_available' ] );
 		}
 	}
 
@@ -188,38 +195,92 @@ class Header_Footer_Elementor {
 	}
 
 	/**
+	 * Prints the admin notics when Elementor is not installed or activated or version outdated.
+	 *
+	 * @since x.x.x
+	 * @param  boolean $is_elementor_callable specifies if elementor is available.
+	 * @param  boolean $is_elementor_outdated specifies if elementor version is old.
+	 */
+	public function elementor_not_available( $is_elementor_callable, $is_elementor_outdated ) {
+
+		if ( ( ! did_action( 'elementor/loaded' ) ) || ( ! $is_elementor_callable ) ) {
+			add_action( 'admin_notices', [ $this, 'elementor_not_installed_activated' ] );
+			add_action( 'network_admin_notices', [ $this, 'elementor_not_installed_activated' ] );
+			return;
+		}
+
+		if ( $is_elementor_outdated ) {
+			add_action( 'admin_notices', [ $this, 'elementor_outdated' ] );
+			add_action( 'network_admin_notices', [ $this, 'elementor_outdated' ] );
+			return;
+		}
+
+	}
+
+	/**
 	 * Prints the admin notics when Elementor is not installed or activated.
 	 */
-	public function elementor_not_available() {
+	public function elementor_not_installed_activated() {
 
-		if ( ! did_action( 'elementor/loaded' ) ) {
-			// Check user capability.
-			if ( ! ( current_user_can( 'activate_plugins' ) && current_user_can( 'install_plugins' ) ) ) {
-				return;
-			}
-
-			/* TO DO */
-			$class = 'notice notice-error';
-			/* translators: %s: html tags */
-			$message = sprintf( __( 'The %1$sElementor - Header Footer and Blocks%2$s plugin requires %1$sElementor%2$s plugin installed & activated.', 'header-footer-elementor' ), '<strong>', '</strong>' );
-
-			$plugin = 'elementor/elementor.php';
-
-			if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
-
-				$action_url   = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . $plugin . '&amp;plugin_status=all&amp;paged=1&amp;s', 'activate-plugin_' . $plugin );
-				$button_label = __( 'Activate Elementor', 'header-footer-elementor' );
-
-			} else {
-
-				$action_url   = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=elementor' ), 'install-plugin_elementor' );
-				$button_label = __( 'Install Elementor', 'header-footer-elementor' );
-			}
-
-			$button = '<p><a href="' . $action_url . '" class="button-primary">' . $button_label . '</a></p><p></p>';
-
-			printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
+		// Check user capability.
+		if ( ! ( current_user_can( 'activate_plugins' ) && current_user_can( 'install_plugins' ) ) ) {
+			return;
 		}
+
+		/* TO DO */
+		$class = 'notice notice-error';
+		/* translators: %s: html tags */
+		$message = sprintf( __( 'The %1$sElementor - Header Footer and Blocks%2$s plugin requires %1$sElementor%2$s plugin installed & activated.', 'header-footer-elementor' ), '<strong>', '</strong>' );
+
+		$plugin = 'elementor/elementor.php';
+
+		if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
+
+			$action_url   = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . $plugin . '&amp;plugin_status=all&amp;paged=1&amp;s', 'activate-plugin_' . $plugin );
+			$button_label = __( 'Activate Elementor', 'header-footer-elementor' );
+
+		} else {
+
+			$action_url   = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=elementor' ), 'install-plugin_elementor' );
+			$button_label = __( 'Install Elementor', 'header-footer-elementor' );
+		}
+
+		$button = '<p><a href="' . esc_url( $action_url ) . '" class="button-primary">' . esc_html( $button_label ) . '</a></p><p></p>';
+
+		printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
+	}
+
+	/**
+	 * Prints the admin notics when Elementor version is outdated.
+	 */
+	public function elementor_outdated() {
+
+		// Check user capability.
+		if ( ! ( current_user_can( 'activate_plugins' ) && current_user_can( 'install_plugins' ) ) ) {
+			return;
+		}
+
+		/* TO DO */
+		$class = 'notice notice-error';
+		/* translators: %s: html tags */
+		$message = sprintf( __( 'The %1$sElementor - Header Footer and Blocks%2$s plugin has stopped working because you are using an older version of %1$sElementor%2$s plugin.', 'header-footer-elementor' ), '<strong>', '</strong>' );
+
+		$plugin = 'elementor/elementor.php';
+
+		if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
+
+			$action_url   = wp_nonce_url( 'update.php?action=upgrade-plugin&amp;plugin=' . $plugin . '&amp;', 'upgrade-plugin_' . $plugin );
+			$button_label = __( 'Update Elementor Now', 'header-footer-elementor' );
+
+		} else {
+
+			$action_url   = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=elementor' ), 'install-plugin_elementor' );
+			$button_label = __( 'Install Elementor', 'header-footer-elementor' );
+		}
+
+		$button = '<p><a href="' . esc_url( $action_url ) . '" class="button-primary">' . esc_html( $button_label ) . '</a></p><p></p>';
+
+		printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
 	}
 
 	/**

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -269,7 +269,7 @@ class Header_Footer_Elementor {
 
 		if ( file_exists( WP_PLUGIN_DIR . '/elementor/elementor.php' ) ) {
 
-			$action_url   = wp_nonce_url( 'update.php?action=upgrade-plugin&amp;plugin=' . $plugin . '&amp;', 'upgrade-plugin_' . $plugin );
+			$action_url   = wp_nonce_url( self_admin_url ( 'update.php?action=upgrade-plugin&amp;plugin=' ) . $plugin . '&amp;', 'upgrade-plugin_' . $plugin );
 			$button_label = __( 'Update Elementor Now', 'header-footer-elementor' );
 
 		} else {

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -197,7 +197,7 @@ class Header_Footer_Elementor {
 	/**
 	 * Prints the admin notics when Elementor is not installed or activated or version outdated.
 	 *
-	 * @since x.x.x
+	 * @since 1.5.9
 	 * @param  boolean $is_elementor_callable specifies if elementor is available.
 	 * @param  boolean $is_elementor_outdated specifies if elementor version is old.
 	 */

--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -515,6 +515,13 @@
 					$( '.elementor-element-' + id + ' li.menu-item:last-child a.hfe-menu-item' ).addClass( 'elementor-button' );
 				}
 			}
+		}else {
+			var $parent_element = $( '.elementor-element-' + id );
+			$parent_element.find( 'nav').removeClass( 'hfe-dropdown' );
+			if( ( 'cta' == last_item || 'cta' == last_item_flyout ) && 'expandible' != layout ){
+				$parent_element.find( 'li.menu-item:last-child a.hfe-menu-item' ).parent().addClass( 'elementor-button-wrapper' );
+				$parent_element.find( 'li.menu-item:last-child a.hfe-menu-item' ).addClass( 'elementor-button' );
+			}
 		}
 
 		var layout = $( '.elementor-element-' + id + ' .hfe-nav-menu' ).data( 'layout' );

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -135,13 +135,21 @@ div.hfe-nav-menu,
           -webkit-justify-content: flex-end;
           -moz-box-pack: end;
           justify-content: flex-end; }
-.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
+
+.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: right;
 }
-.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
+.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: left;
 }
-.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
+.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: center;
 }
 .hfe-nav-menu__align-left .hfe-nav-menu {

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -9,11 +9,9 @@ namespace HFE\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Text_Shadow;
-use Elementor\Scheme_Color;
-use Elementor\Core\Schemes;
 use Elementor\Group_Control_Border;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -250,7 +248,9 @@ class Cart extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'      => 'toggle_button_typography',
-				'scheme'    => Schemes\Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector'  => '{{WRAPPER}} .hfe-menu-cart__toggle .elementor-button',
 				'condition' => [
 					'hfe_cart_type' => 'custom',

--- a/inc/widgets-manager/widgets/class-copyright.php
+++ b/inc/widgets-manager/widgets/class-copyright.php
@@ -10,8 +10,8 @@ namespace HFE\WidgetsManager\Widgets;
 use Elementor\Controls_Manager;
 use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Widget_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -166,9 +166,8 @@ class Copyright extends Widget_Base {
 			[
 				'label'     => __( 'Text Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
 					// Stronger selector to avoid section style from overwriting.
@@ -182,7 +181,9 @@ class Copyright extends Widget_Base {
 			[
 				'name'     => 'caption_typography',
 				'selector' => '{{WRAPPER}} .hfe-copyright-wrapper, {{WRAPPER}} .hfe-copyright-wrapper a',
-				'scheme'   => Scheme_Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			]
 		);
 	}

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -11,8 +11,8 @@ namespace HFE\WidgetsManager\Widgets;
 use Elementor\Controls_Manager;
 use Elementor\Utils;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Background;
@@ -904,7 +904,9 @@ class Navigation_Menu extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'      => 'menu_typography',
-				'scheme'    => Scheme_Typography::TYPOGRAPHY_1,
+				'global'    => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'separator' => 'before',
 				'selector'  => '{{WRAPPER}} a.hfe-menu-item, {{WRAPPER}} a.hfe-sub-menu-item',
 			]
@@ -924,9 +926,8 @@ class Navigation_Menu extends Widget_Base {
 						[
 							'label'     => __( 'Text Color', 'header-footer-elementor' ),
 							'type'      => Controls_Manager::COLOR,
-							'scheme'    => [
-								'type'  => Scheme_Color::get_type(),
-								'value' => Scheme_Color::COLOR_3,
+							'global'    => [
+								'default' => Global_Colors::COLOR_TEXT,
 							],
 							'default'   => '',
 							'selectors' => [
@@ -964,9 +965,8 @@ class Navigation_Menu extends Widget_Base {
 						[
 							'label'     => __( 'Text Color', 'header-footer-elementor' ),
 							'type'      => Controls_Manager::COLOR,
-							'scheme'    => [
-								'type'  => Scheme_Color::get_type(),
-								'value' => Scheme_Color::COLOR_4,
+							'global'    => [
+								'default' => Global_Colors::COLOR_ACCENT,
 							],
 							'selectors' => [
 								'{{WRAPPER}} .menu-item a.hfe-menu-item:hover,
@@ -1001,9 +1001,8 @@ class Navigation_Menu extends Widget_Base {
 						[
 							'label'     => __( 'Link Hover Effect Color', 'header-footer-elementor' ),
 							'type'      => Controls_Manager::COLOR,
-							'scheme'    => [
-								'type'  => Scheme_Color::get_type(),
-								'value' => Scheme_Color::COLOR_4,
+							'global'    => [
+								'default' => Global_Colors::COLOR_ACCENT,
 							],
 							'default'   => '',
 							'selectors' => [
@@ -1252,7 +1251,9 @@ class Navigation_Menu extends Widget_Base {
 				Group_Control_Typography::get_type(),
 				[
 					'name'      => 'dropdown_typography',
-					'scheme'    => Scheme_Typography::TYPOGRAPHY_4,
+					'global'    => [
+						'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+					],
 					'separator' => 'before',
 					'selector'  => '
 							{{WRAPPER}} .sub-menu li a.hfe-sub-menu-item,
@@ -1652,7 +1653,9 @@ class Navigation_Menu extends Widget_Base {
 				[
 					'name'     => 'all_typography',
 					'label'    => __( 'Typography', 'header-footer-elementor' ),
-					'scheme'   => Scheme_Typography::TYPOGRAPHY_4,
+					'global'   => [
+						'default' => Global_Typography::TYPOGRAPHY_ACCENT,
+					],
 					'selector' => '{{WRAPPER}} .menu-item a.hfe-menu-item.elementor-button',
 				]
 			);
@@ -1698,9 +1701,8 @@ class Navigation_Menu extends Widget_Base {
 							'selector'       => '{{WRAPPER}} .menu-item a.hfe-menu-item.elementor-button',
 							'fields_options' => [
 								'color' => [
-									'scheme' => [
-										'type'  => Scheme_Color::get_type(),
-										'value' => Scheme_Color::COLOR_4,
+									'global' => [
+										'default' => Global_Colors::COLOR_ACCENT,
 									],
 								],
 							],
@@ -1765,9 +1767,8 @@ class Navigation_Menu extends Widget_Base {
 							'selector'       => '{{WRAPPER}} .menu-item a.hfe-menu-item.elementor-button:hover',
 							'fields_options' => [
 								'color' => [
-									'scheme' => [
-										'type'  => Scheme_Color::get_type(),
-										'value' => Scheme_Color::COLOR_4,
+									'global' => [
+										'default' => Global_Colors::COLOR_ACCENT,
 									],
 								],
 							],

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -11,8 +11,8 @@ use Elementor\Controls_Manager;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 
 use HFE\WidgetsManager\Widgets_Loader;
 
@@ -299,7 +299,9 @@ class Page_Title extends Widget_Base {
 				Group_Control_Typography::get_type(),
 				[
 					'name'     => 'title_typography',
-					'scheme'   => Scheme_Typography::TYPOGRAPHY_1,
+					'global'   => [
+						'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+					],
 					'selector' => '{{WRAPPER}} .elementor-heading-title, {{WRAPPER}} .hfe-page-title a',
 				]
 			);
@@ -309,9 +311,8 @@ class Page_Title extends Widget_Base {
 				[
 					'label'     => __( 'Color', 'header-footer-elementor' ),
 					'type'      => Controls_Manager::COLOR,
-					'scheme'    => [
-						'type'  => Scheme_Color::get_type(),
-						'value' => Scheme_Color::COLOR_1,
+					'global'    => [
+						'default' => Global_Colors::COLOR_PRIMARY,
 					],
 					'selectors' => [
 						'{{WRAPPER}} .elementor-heading-title, {{WRAPPER}} .hfe-page-title a' => 'color: {{VALUE}};',
@@ -373,9 +374,8 @@ class Page_Title extends Widget_Base {
 			[
 				'label'     => __( 'Icon Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'new_page_title_select_icon[value]!' => '',

--- a/inc/widgets-manager/widgets/class-retina.php
+++ b/inc/widgets-manager/widgets/class-retina.php
@@ -13,8 +13,8 @@ use Elementor\Utils;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Scheme_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Group_Control_Css_Filter;
 use Elementor\Group_Control_Text_Shadow;
@@ -380,9 +380,8 @@ class Retina extends Widget_Base {
 			[
 				'label'     => __( 'Border Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'retina_image_border!' => 'none',
@@ -543,9 +542,8 @@ class Retina extends Widget_Base {
 				'selectors' => [
 					'{{WRAPPER}} .widget-image-caption' => 'color: {{VALUE}};',
 				],
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 			]
 		);
@@ -566,7 +564,9 @@ class Retina extends Widget_Base {
 			[
 				'name'     => 'caption_typography',
 				'selector' => '{{WRAPPER}} .widget-image-caption',
-				'scheme'   => Scheme_Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			]
 		);
 

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -9,11 +9,11 @@ namespace HFE\WidgetsManager\Widgets;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Background;
-use Elementor\Scheme_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Text_Shadow;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Group_Control_Border;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -204,7 +204,9 @@ class Search_Button extends Widget_Base {
 			[
 				'name'     => 'input_typography',
 				'selector' => '{{WRAPPER}} input[type="search"].hfe-search-form__input,{{WRAPPER}} .hfe-search-icon-toggle',
-				'scheme'   => Scheme_Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 			]
 		);
 
@@ -248,9 +250,8 @@ class Search_Button extends Widget_Base {
 			[
 				'label'     => __( 'Text Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .hfe-search-form__input' => 'color: {{VALUE}}',
@@ -266,9 +267,8 @@ class Search_Button extends Widget_Base {
 			[
 				'label'     => __( 'Placeholder Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .hfe-search-form__input::placeholder' => 'color: {{VALUE}}',
@@ -334,9 +334,8 @@ class Search_Button extends Widget_Base {
 			[
 				'label'     => __( 'Border Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'border_style!' => 'none',
@@ -433,9 +432,8 @@ class Search_Button extends Widget_Base {
 			[
 				'label'     => __( 'Placeholder Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .hfe-search-form__input:focus::placeholder' => 'color: {{VALUE}}',
@@ -890,9 +888,8 @@ class Search_Button extends Widget_Base {
 			[
 				'label'     => __( 'Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 				'default'   => '#7a7a7a',
 				'selectors' => [

--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -13,8 +13,8 @@ use Elementor\Utils;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Typography;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Scheme_Typography;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Group_Control_Image_Size;
 use Elementor\Repeater;
 use Elementor\Group_Control_Css_Filter;
@@ -422,9 +422,8 @@ class Site_Logo extends Widget_Base {
 			[
 				'label'     => __( 'Border Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'site_logo_image_border!' => 'none',
@@ -585,9 +584,8 @@ class Site_Logo extends Widget_Base {
 				'selectors' => [
 					'{{WRAPPER}} .widget-image-caption' => 'color: {{VALUE}};',
 				],
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_3,
+				'global'    => [
+					'default' => Global_Colors::COLOR_TEXT,
 				],
 			]
 		);
@@ -608,7 +606,9 @@ class Site_Logo extends Widget_Base {
 			[
 				'name'     => 'caption_typography',
 				'selector' => '{{WRAPPER}} .widget-image-caption',
-				'scheme'   => Scheme_Typography::TYPOGRAPHY_3,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
 			]
 		);
 

--- a/inc/widgets-manager/widgets/class-site-tagline.php
+++ b/inc/widgets-manager/widgets/class-site-tagline.php
@@ -9,10 +9,10 @@ namespace HFE\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Text_Shadow;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;   // Exit if accessed directly.
@@ -205,7 +205,9 @@ class Site_Tagline extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'     => 'tagline_typography',
-				'scheme'   => Scheme_Typography::TYPOGRAPHY_2,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
 				'selector' => '{{WRAPPER}} .hfe-site-tagline',
 			]
 		);
@@ -214,9 +216,8 @@ class Site_Tagline extends Widget_Base {
 			[
 				'label'     => __( 'Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_2,
+				'global'    => [
+					'default' => Global_Colors::COLOR_SECONDARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .hfe-site-tagline' => 'color: {{VALUE}};',
@@ -231,9 +232,8 @@ class Site_Tagline extends Widget_Base {
 			[
 				'label'     => __( 'Icon Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'icon[value]!' => '',

--- a/inc/widgets-manager/widgets/class-site-title.php
+++ b/inc/widgets-manager/widgets/class-site-title.php
@@ -9,10 +9,10 @@ namespace HFE\WidgetsManager\Widgets;
 
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Scheme_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Widget_Base;
 use Elementor\Group_Control_Text_Shadow;
-use Elementor\Scheme_Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 
 use HFE\WidgetsManager\Widgets_Loader;
 
@@ -290,7 +290,9 @@ class Site_Title extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 				'name'     => 'heading_typography',
-				'scheme'   => Scheme_Typography::TYPOGRAPHY_1,
+				'global'   => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'selector' => '{{WRAPPER}} .elementor-heading-title, {{WRAPPER}} .hfe-heading a',
 			]
 		);
@@ -299,9 +301,8 @@ class Site_Title extends Widget_Base {
 			[
 				'label'     => __( 'Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .hfe-heading-text' => 'color: {{VALUE}};',
@@ -362,9 +363,8 @@ class Site_Title extends Widget_Base {
 			[
 				'label'     => __( 'Icon Color', 'header-footer-elementor' ),
 				'type'      => Controls_Manager::COLOR,
-				'scheme'    => [
-					'type'  => Scheme_Color::get_type(),
-					'value' => Scheme_Color::COLOR_1,
+				'global'    => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'condition' => [
 					'icon[value]!' => '',

--- a/languages/header-footer-elementor.pot
+++ b/languages/header-footer-elementor.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Elementor - Header, Footer & Blocks package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Elementor - Header, Footer & Blocks 1.5.8\n"
+"Project-Id-Version: Elementor - Header, Footer & Blocks 1.5.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/header-footer-elementor\n"
-"POT-Creation-Date: 2021-03-31 07:50:44+00:00\n"
+"POT-Creation-Date: 2021-04-19 09:30:20+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -424,21 +424,21 @@ msgid "Header, Footer & Blocks"
 msgstr ""
 
 #: inc/widgets-manager/class-widgets-loader.php:234
-#: inc/widgets-manager/widgets/class-cart.php:53
+#: inc/widgets-manager/widgets/class-cart.php:51
 #: inc/widgets-manager/widgets/class-cart.php:661
 msgid "Cart"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:121
-#: inc/widgets-manager/widgets/class-cart.php:244
+#: inc/widgets-manager/widgets/class-cart.php:119
+#: inc/widgets-manager/widgets/class-cart.php:242
 msgid "Menu Cart"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:128
+#: inc/widgets-manager/widgets/class-cart.php:126
 msgid "Type"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:132
+#: inc/widgets-manager/widgets/class-cart.php:130
 #: inc/widgets-manager/widgets/class-navigation-menu.php:237
 #: inc/widgets-manager/widgets/class-navigation-menu.php:441
 #: inc/widgets-manager/widgets/class-page-title.php:192
@@ -450,63 +450,63 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:133
+#: inc/widgets-manager/widgets/class-cart.php:131
 msgid "Custom"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:141
+#: inc/widgets-manager/widgets/class-cart.php:139
 #: inc/widgets-manager/widgets/class-navigation-menu.php:571
-#: inc/widgets-manager/widgets/class-page-title.php:363
+#: inc/widgets-manager/widgets/class-page-title.php:364
 #: inc/widgets-manager/widgets/class-search-button.php:145
-#: inc/widgets-manager/widgets/class-search-button.php:769
+#: inc/widgets-manager/widgets/class-search-button.php:767
 #: inc/widgets-manager/widgets/class-site-tagline.php:150
 #: inc/widgets-manager/widgets/class-site-title.php:152
-#: inc/widgets-manager/widgets/class-site-title.php:353
+#: inc/widgets-manager/widgets/class-site-title.php:354
 msgid "Icon"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:144
+#: inc/widgets-manager/widgets/class-cart.php:142
 msgid "Bag Light"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:145
+#: inc/widgets-manager/widgets/class-cart.php:143
 msgid "Bag Medium"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:146
+#: inc/widgets-manager/widgets/class-cart.php:144
 msgid "Bag Solid"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:159
+#: inc/widgets-manager/widgets/class-cart.php:157
 #: inc/widgets-manager/widgets/class-cart.php:497
 msgid "Items Count"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:162
+#: inc/widgets-manager/widgets/class-cart.php:160
 #: inc/widgets-manager/widgets/class-navigation-menu.php:487
 #: inc/widgets-manager/widgets/class-navigation-menu.php:819
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1420
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1421
 #: inc/widgets-manager/widgets/class-page-title.php:193
 #: inc/widgets-manager/widgets/class-retina.php:196
 #: inc/widgets-manager/widgets/class-retina.php:227
 #: inc/widgets-manager/widgets/class-retina.php:345
 #: inc/widgets-manager/widgets/class-search-button.php:317
-#: inc/widgets-manager/widgets/class-search-button.php:557
+#: inc/widgets-manager/widgets/class-search-button.php:555
 #: inc/widgets-manager/widgets/class-site-logo.php:233
 #: inc/widgets-manager/widgets/class-site-logo.php:387
 msgid "None"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:163
+#: inc/widgets-manager/widgets/class-cart.php:161
 msgid "Bubble"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:176
+#: inc/widgets-manager/widgets/class-cart.php:174
 msgid "Show Total Price"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:178
-#: inc/widgets-manager/widgets/class-cart.php:194
+#: inc/widgets-manager/widgets/class-cart.php:176
+#: inc/widgets-manager/widgets/class-cart.php:192
 #: inc/widgets-manager/widgets/class-navigation-menu.php:249
 #: inc/widgets-manager/widgets/class-navigation-menu.php:539
 #: inc/widgets-manager/widgets/class-site-logo.php:137
@@ -515,8 +515,8 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:179
-#: inc/widgets-manager/widgets/class-cart.php:195
+#: inc/widgets-manager/widgets/class-cart.php:177
+#: inc/widgets-manager/widgets/class-cart.php:193
 #: inc/widgets-manager/widgets/class-navigation-menu.php:250
 #: inc/widgets-manager/widgets/class-navigation-menu.php:540
 #: inc/widgets-manager/widgets/class-site-logo.php:138
@@ -525,15 +525,15 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:192
+#: inc/widgets-manager/widgets/class-cart.php:190
 msgid "Hide Empty"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:198
+#: inc/widgets-manager/widgets/class-cart.php:196
 msgid "This will hide the items count until the cart is empty"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:209
+#: inc/widgets-manager/widgets/class-cart.php:207
 #: inc/widgets-manager/widgets/class-copyright.php:142
 #: inc/widgets-manager/widgets/class-navigation-menu.php:284
 #: inc/widgets-manager/widgets/class-navigation-menu.php:500
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Alignment"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:213
+#: inc/widgets-manager/widgets/class-cart.php:211
 #: inc/widgets-manager/widgets/class-copyright.php:146
 #: inc/widgets-manager/widgets/class-navigation-menu.php:288
 #: inc/widgets-manager/widgets/class-navigation-menu.php:319
@@ -560,7 +560,7 @@ msgstr ""
 msgid "Left"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:217
+#: inc/widgets-manager/widgets/class-cart.php:215
 #: inc/widgets-manager/widgets/class-copyright.php:150
 #: inc/widgets-manager/widgets/class-navigation-menu.php:292
 #: inc/widgets-manager/widgets/class-navigation-menu.php:358
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Center"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-cart.php:221
+#: inc/widgets-manager/widgets/class-cart.php:219
 #: inc/widgets-manager/widgets/class-copyright.php:154
 #: inc/widgets-manager/widgets/class-navigation-menu.php:296
 #: inc/widgets-manager/widgets/class-navigation-menu.php:320
@@ -592,34 +592,34 @@ msgstr ""
 #: inc/widgets-manager/widgets/class-cart.php:263
 #: inc/widgets-manager/widgets/class-page-title.php:237
 #: inc/widgets-manager/widgets/class-search-button.php:168
-#: inc/widgets-manager/widgets/class-search-button.php:859
+#: inc/widgets-manager/widgets/class-search-button.php:857
 #: inc/widgets-manager/widgets/class-site-title.php:211
 msgid "Size"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:282
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1453
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1575
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1454
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1576
 #: inc/widgets-manager/widgets/class-retina.php:359
-#: inc/widgets-manager/widgets/class-search-button.php:357
-#: inc/widgets-manager/widgets/class-search-button.php:591
+#: inc/widgets-manager/widgets/class-search-button.php:356
+#: inc/widgets-manager/widgets/class-search-button.php:589
 #: inc/widgets-manager/widgets/class-site-logo.php:401
 msgid "Border Width"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:301
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1280
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1591
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1722
-#: inc/widgets-manager/widgets/class-retina.php:400
-#: inc/widgets-manager/widgets/class-search-button.php:382
-#: inc/widgets-manager/widgets/class-search-button.php:614
-#: inc/widgets-manager/widgets/class-site-logo.php:442
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1281
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1592
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1724
+#: inc/widgets-manager/widgets/class-retina.php:399
+#: inc/widgets-manager/widgets/class-search-button.php:381
+#: inc/widgets-manager/widgets/class-search-button.php:612
+#: inc/widgets-manager/widgets/class-site-logo.php:441
 msgid "Border Radius"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:321
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1662
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1665
 #: inc/widgets-manager/widgets/class-retina.php:584
 #: inc/widgets-manager/widgets/class-site-logo.php:626
 msgid "Padding"
@@ -627,18 +627,18 @@ msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:338
 #: inc/widgets-manager/widgets/class-cart.php:536
-#: inc/widgets-manager/widgets/class-navigation-menu.php:918
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1124
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1490
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1676
-#: inc/widgets-manager/widgets/class-page-title.php:338
-#: inc/widgets-manager/widgets/class-retina.php:425
-#: inc/widgets-manager/widgets/class-search-button.php:239
-#: inc/widgets-manager/widgets/class-search-button.php:653
-#: inc/widgets-manager/widgets/class-search-button.php:782
-#: inc/widgets-manager/widgets/class-search-button.php:885
-#: inc/widgets-manager/widgets/class-site-logo.php:467
-#: inc/widgets-manager/widgets/class-site-title.php:328
+#: inc/widgets-manager/widgets/class-navigation-menu.php:920
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1123
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1491
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1679
+#: inc/widgets-manager/widgets/class-page-title.php:339
+#: inc/widgets-manager/widgets/class-retina.php:424
+#: inc/widgets-manager/widgets/class-search-button.php:241
+#: inc/widgets-manager/widgets/class-search-button.php:651
+#: inc/widgets-manager/widgets/class-search-button.php:780
+#: inc/widgets-manager/widgets/class-search-button.php:883
+#: inc/widgets-manager/widgets/class-site-logo.php:466
+#: inc/widgets-manager/widgets/class-site-title.php:329
 msgid "Normal"
 msgstr ""
 
@@ -647,29 +647,29 @@ msgstr ""
 #: inc/widgets-manager/widgets/class-cart.php:543
 #: inc/widgets-manager/widgets/class-cart.php:580
 #: inc/widgets-manager/widgets/class-copyright.php:167
-#: inc/widgets-manager/widgets/class-navigation-menu.php:925
-#: inc/widgets-manager/widgets/class-navigation-menu.php:965
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1035
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1131
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1174
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1217
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1683
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1751
-#: inc/widgets-manager/widgets/class-retina.php:540
-#: inc/widgets-manager/widgets/class-search-button.php:249
-#: inc/widgets-manager/widgets/class-search-button.php:419
-#: inc/widgets-manager/widgets/class-search-button.php:504
-#: inc/widgets-manager/widgets/class-search-button.php:693
-#: inc/widgets-manager/widgets/class-site-logo.php:582
+#: inc/widgets-manager/widgets/class-navigation-menu.php:927
+#: inc/widgets-manager/widgets/class-navigation-menu.php:966
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1034
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1130
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1173
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1216
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1686
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1753
+#: inc/widgets-manager/widgets/class-retina.php:539
+#: inc/widgets-manager/widgets/class-search-button.php:251
+#: inc/widgets-manager/widgets/class-search-button.php:418
+#: inc/widgets-manager/widgets/class-search-button.php:502
+#: inc/widgets-manager/widgets/class-search-button.php:691
+#: inc/widgets-manager/widgets/class-site-logo.php:581
 msgid "Text Color"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:356
 #: inc/widgets-manager/widgets/class-cart.php:412
-#: inc/widgets-manager/widgets/class-page-title.php:374
-#: inc/widgets-manager/widgets/class-search-button.php:660
-#: inc/widgets-manager/widgets/class-site-tagline.php:232
-#: inc/widgets-manager/widgets/class-site-title.php:363
+#: inc/widgets-manager/widgets/class-page-title.php:375
+#: inc/widgets-manager/widgets/class-search-button.php:658
+#: inc/widgets-manager/widgets/class-site-tagline.php:233
+#: inc/widgets-manager/widgets/class-site-title.php:364
 msgid "Icon Color"
 msgstr ""
 
@@ -678,56 +678,56 @@ msgstr ""
 #: inc/widgets-manager/widgets/class-cart.php:557
 #: inc/widgets-manager/widgets/class-cart.php:594
 #: inc/widgets-manager/widgets/class-navigation-menu.php:800
-#: inc/widgets-manager/widgets/class-navigation-menu.php:941
+#: inc/widgets-manager/widgets/class-navigation-menu.php:942
 #: inc/widgets-manager/widgets/class-navigation-menu.php:984
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1048
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1148
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1191
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1234
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1509
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1542
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1696
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1763
-#: inc/widgets-manager/widgets/class-retina.php:556
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1047
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1147
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1190
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1233
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1510
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1543
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1699
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1765
+#: inc/widgets-manager/widgets/class-retina.php:554
 #: inc/widgets-manager/widgets/class-search-button.php:286
-#: inc/widgets-manager/widgets/class-search-button.php:452
-#: inc/widgets-manager/widgets/class-search-button.php:519
-#: inc/widgets-manager/widgets/class-search-button.php:672
-#: inc/widgets-manager/widgets/class-search-button.php:704
+#: inc/widgets-manager/widgets/class-search-button.php:450
+#: inc/widgets-manager/widgets/class-search-button.php:517
+#: inc/widgets-manager/widgets/class-search-button.php:670
+#: inc/widgets-manager/widgets/class-search-button.php:702
 #: inc/widgets-manager/widgets/class-site-logo.php:371
-#: inc/widgets-manager/widgets/class-site-logo.php:598
+#: inc/widgets-manager/widgets/class-site-logo.php:596
 msgid "Background Color"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:381
 #: inc/widgets-manager/widgets/class-cart.php:437
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1436
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1437
 #: inc/widgets-manager/widgets/class-retina.php:381
 #: inc/widgets-manager/widgets/class-search-button.php:335
-#: inc/widgets-manager/widgets/class-search-button.php:485
-#: inc/widgets-manager/widgets/class-search-button.php:575
+#: inc/widgets-manager/widgets/class-search-button.php:483
+#: inc/widgets-manager/widgets/class-search-button.php:573
 #: inc/widgets-manager/widgets/class-site-logo.php:423
 msgid "Border Color"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:394
 #: inc/widgets-manager/widgets/class-cart.php:573
-#: inc/widgets-manager/widgets/class-navigation-menu.php:958
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1167
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1522
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1744
-#: inc/widgets-manager/widgets/class-retina.php:460
-#: inc/widgets-manager/widgets/class-search-button.php:686
-#: inc/widgets-manager/widgets/class-search-button.php:802
-#: inc/widgets-manager/widgets/class-search-button.php:910
-#: inc/widgets-manager/widgets/class-site-logo.php:502
+#: inc/widgets-manager/widgets/class-navigation-menu.php:959
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1166
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1523
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1746
+#: inc/widgets-manager/widgets/class-retina.php:459
+#: inc/widgets-manager/widgets/class-search-button.php:684
+#: inc/widgets-manager/widgets/class-search-button.php:800
+#: inc/widgets-manager/widgets/class-search-button.php:907
+#: inc/widgets-manager/widgets/class-site-logo.php:501
 msgid "Hover"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-cart.php:451
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1557
-#: inc/widgets-manager/widgets/class-search-button.php:719
-#: inc/widgets-manager/widgets/class-search-button.php:824
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1558
+#: inc/widgets-manager/widgets/class-search-button.php:717
+#: inc/widgets-manager/widgets/class-search-button.php:822
 msgid "Icon Size"
 msgstr ""
 
@@ -805,8 +805,8 @@ msgid "Last Menu Item"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-navigation-menu.php:238
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1642
-#: inc/widgets-manager/widgets/class-search-button.php:640
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1643
+#: inc/widgets-manager/widgets/class-search-button.php:638
 msgid "Button"
 msgstr ""
 
@@ -941,7 +941,7 @@ msgstr ""
 
 #: inc/widgets-manager/widgets/class-navigation-menu.php:586
 #: inc/widgets-manager/widgets/class-navigation-menu.php:602
-#: inc/widgets-manager/widgets/class-search-button.php:848
+#: inc/widgets-manager/widgets/class-search-button.php:846
 msgid "Close Icon"
 msgstr ""
 
@@ -958,12 +958,12 @@ msgid "Flyout Box Padding"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-navigation-menu.php:688
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1338
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1339
 msgid "Horizontal Padding"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-navigation-menu.php:713
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1360
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1361
 msgid "Vertical Padding"
 msgstr ""
 
@@ -1013,110 +1013,110 @@ msgid "Frame Animation"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-navigation-menu.php:1002
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1064
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1063
 msgid "Link Hover Effect Color"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1028
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1210
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1027
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1209
 msgid "Active"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1099
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1098
 msgid "Dropdown"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1107
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1106
 msgid ""
 "<b>Note:</b> On desktop, below style options will apply to the submenu. On "
 "mobile, this will apply to the entire menu."
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1314
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1315
 msgid "Dropdown Width (px)"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1385
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1386
 msgid "Top Distance"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1406
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1407
 msgid "Divider"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1415
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1416
 #: inc/widgets-manager/widgets/class-retina.php:340
 #: inc/widgets-manager/widgets/class-search-button.php:312
-#: inc/widgets-manager/widgets/class-search-button.php:552
+#: inc/widgets-manager/widgets/class-search-button.php:550
 #: inc/widgets-manager/widgets/class-site-logo.php:382
 msgid "Border Style"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1421
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1422
 #: inc/widgets-manager/widgets/class-retina.php:346
 #: inc/widgets-manager/widgets/class-search-button.php:318
-#: inc/widgets-manager/widgets/class-search-button.php:558
+#: inc/widgets-manager/widgets/class-search-button.php:556
 #: inc/widgets-manager/widgets/class-site-logo.php:388
 msgid "Solid"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1422
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1423
 #: inc/widgets-manager/widgets/class-retina.php:347
 #: inc/widgets-manager/widgets/class-search-button.php:319
-#: inc/widgets-manager/widgets/class-search-button.php:559
+#: inc/widgets-manager/widgets/class-search-button.php:557
 #: inc/widgets-manager/widgets/class-site-logo.php:389
 msgid "Double"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1423
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1424
 #: inc/widgets-manager/widgets/class-retina.php:348
 #: inc/widgets-manager/widgets/class-search-button.php:320
-#: inc/widgets-manager/widgets/class-search-button.php:560
+#: inc/widgets-manager/widgets/class-search-button.php:558
 #: inc/widgets-manager/widgets/class-site-logo.php:390
 msgid "Dotted"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1424
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1425
 #: inc/widgets-manager/widgets/class-retina.php:349
 #: inc/widgets-manager/widgets/class-search-button.php:321
-#: inc/widgets-manager/widgets/class-search-button.php:561
+#: inc/widgets-manager/widgets/class-search-button.php:559
 #: inc/widgets-manager/widgets/class-site-logo.php:391
 msgid "Dashed"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1480
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1481
 msgid "Menu Trigger & Close Icon"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1497
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1529
-#: inc/widgets-manager/widgets/class-page-title.php:310
-#: inc/widgets-manager/widgets/class-search-button.php:789
-#: inc/widgets-manager/widgets/class-search-button.php:809
-#: inc/widgets-manager/widgets/class-search-button.php:891
-#: inc/widgets-manager/widgets/class-search-button.php:917
-#: inc/widgets-manager/widgets/class-site-tagline.php:215
-#: inc/widgets-manager/widgets/class-site-title.php:300
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1498
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1530
+#: inc/widgets-manager/widgets/class-page-title.php:312
+#: inc/widgets-manager/widgets/class-search-button.php:787
+#: inc/widgets-manager/widgets/class-search-button.php:807
+#: inc/widgets-manager/widgets/class-search-button.php:889
+#: inc/widgets-manager/widgets/class-search-button.php:914
+#: inc/widgets-manager/widgets/class-site-tagline.php:217
+#: inc/widgets-manager/widgets/class-site-title.php:302
 msgid "Color"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1603
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1604
 msgid "Close Icon Color"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1621
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1622
 msgid "Close Icon Size"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1654
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1655
 msgid "Typography"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1714
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1716
 msgid "Border"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-navigation-menu.php:1780
+#: inc/widgets-manager/widgets/class-navigation-menu.php:1781
 msgid "Border Hover Color"
 msgstr ""
 
@@ -1222,8 +1222,8 @@ msgstr ""
 msgid "Justified"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-page-title.php:335
-#: inc/widgets-manager/widgets/class-site-title.php:325
+#: inc/widgets-manager/widgets/class-page-title.php:336
+#: inc/widgets-manager/widgets/class-site-title.php:326
 msgid "Blend Mode"
 msgstr ""
 
@@ -1253,9 +1253,9 @@ msgid "Image Size"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-retina.php:193
-#: inc/widgets-manager/widgets/class-retina.php:529
+#: inc/widgets-manager/widgets/class-retina.php:528
 #: inc/widgets-manager/widgets/class-site-logo.php:198
-#: inc/widgets-manager/widgets/class-site-logo.php:571
+#: inc/widgets-manager/widgets/class-site-logo.php:570
 msgid "Caption"
 msgstr ""
 
@@ -1270,8 +1270,8 @@ msgid "Enter your image caption"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-retina.php:268
-#: inc/widgets-manager/widgets/class-search-button.php:214
-#: inc/widgets-manager/widgets/class-search-button.php:745
+#: inc/widgets-manager/widgets/class-search-button.php:216
+#: inc/widgets-manager/widgets/class-search-button.php:743
 #: inc/widgets-manager/widgets/class-site-logo.php:301
 msgid "Width"
 msgstr ""
@@ -1281,20 +1281,20 @@ msgstr ""
 msgid "Max Width"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-retina.php:432
-#: inc/widgets-manager/widgets/class-retina.php:466
-#: inc/widgets-manager/widgets/class-site-logo.php:474
-#: inc/widgets-manager/widgets/class-site-logo.php:508
+#: inc/widgets-manager/widgets/class-retina.php:431
+#: inc/widgets-manager/widgets/class-retina.php:465
+#: inc/widgets-manager/widgets/class-site-logo.php:473
+#: inc/widgets-manager/widgets/class-site-logo.php:507
 msgid "Opacity"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-retina.php:492
-#: inc/widgets-manager/widgets/class-site-logo.php:550
+#: inc/widgets-manager/widgets/class-retina.php:491
+#: inc/widgets-manager/widgets/class-site-logo.php:549
 msgid "Hover Animation"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-retina.php:499
-#: inc/widgets-manager/widgets/class-site-logo.php:525
+#: inc/widgets-manager/widgets/class-retina.php:498
+#: inc/widgets-manager/widgets/class-site-logo.php:524
 msgid "Transition Duration"
 msgstr ""
 
@@ -1312,7 +1312,7 @@ msgid "%1$s Getting started article » %2$s"
 msgstr ""
 
 #: inc/widgets-manager/widgets/class-search-button.php:54
-#: inc/widgets-manager/widgets/class-search-button.php:952
+#: inc/widgets-manager/widgets/class-search-button.php:949
 msgid "Search"
 msgstr ""
 
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Input"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-search-button.php:267
-#: inc/widgets-manager/widgets/class-search-button.php:434
+#: inc/widgets-manager/widgets/class-search-button.php:268
+#: inc/widgets-manager/widgets/class-search-button.php:433
 msgid "Placeholder Color"
 msgstr ""
 
-#: inc/widgets-manager/widgets/class-search-button.php:409
+#: inc/widgets-manager/widgets/class-search-button.php:408
 msgid "Focus"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.5.9 = 
+- Improvement: Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 
 = 1.5.8 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
 Tested up to: 5.7
-Stable tag: 1.5.8
+Stable tag: 1.5.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 = 1.5.9 = 
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
+- Fix: Navigation Menu - Last menu item button alignment not working in RTL view.
 
 = 1.5.8 =
 - Fix: Hardened allowed options in the editor to enforce better security policies.

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.5.9 = 
+- Improvement: Added notice to update the Elementor version to 3.0.0 or higher.
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 - Fix: Navigation Menu - Last menu item button alignment not working in RTL view.

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.5.9 = 
+- Improvement: Added notice to update Elementor to v3.0.0 or higher
+Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 
 - Improvement: Added notice to update the Elementor version to 3.0.0 or higher.
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 

--- a/readme.txt
+++ b/readme.txt
@@ -138,7 +138,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.5.9 = 
-- Improvement: Added Elementor Global Color and Typography scheme support.
+- Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 
 = 1.5.8 =

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 == Changelog ==
+= 1.5.9 = 
+- Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
+
 = 1.5.8 =
 - Fix: Hardened allowed options in the editor to enforce better security policies.
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,6 @@ This same applies when you are creating your Header/Footer using this plugin.
 = 1.5.9 = 
 - Improvement: Added notice to update Elementor to v3.0.0 or higher
 Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 
-- Improvement: Added notice to update the Elementor version to 3.0.0 or higher.
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
 - Fix: Navigation Menu - Last menu item button alignment not working in RTL view.


### PR DESCRIPTION
### Description
Added Elementor 3.2 compatibility and fixes in the PR. Please refer to the below changelog - 
- Improvement: Added notice to update Elementor to v3.0.0 or higher
Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 
- Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
- Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
- Fix: Navigation Menu - Last menu item button alignment not working in RTL view.

Note: Did not find any issues related to Elementor & Elementor PRo's 3.2 version

### Screenshots
N/A

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Improvements and Fixes (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
- Upgrade to Elementor 3.2 and test scheme color, typography controls in widgets
- Check if Navigation Menu's last menu item button disappearing while switching from mobile to desktop issue fixed. 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
