### PR TITLE
Feat: Added Elementor version check notice

### DIFF
--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -197,11 +197,10 @@ class Header_Footer_Elementor {
 
 	/**
 	 * Prints the admin notics when Elementor is not installed or activated or version outdated.
-	 * 
+	 *
 	 * @since x.x.x
 	 * @param  boolean $is_elementor_callable specifies if elementor is available.
 	 * @param  boolean $is_elementor_outdated specifies if elementor version is old.
-	 *
 	 */
 	public function elementor_not_available( $is_elementor_callable, $is_elementor_outdated ) {
 

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -53,7 +53,7 @@ class Header_Footer_Elementor {
 
 		$is_elementor_callable = ( defined( 'ELEMENTOR_VERSION' ) && is_callable( 'Elementor\Plugin::instance' ) ) ? true : false;
 
-		$required_elementor_version = '3.1.0';
+		$required_elementor_version = '3.0.0';
 
 		$is_elementor_outdated = ( $is_elementor_callable && ( ! version_compare( ELEMENTOR_VERSION, $required_elementor_version, '>=' ) ) ) ? true : false;
 

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -264,7 +264,7 @@ class Header_Footer_Elementor {
 		/* TO DO */
 		$class = 'notice notice-error';
 		/* translators: %s: html tags */
-		$message = sprintf( __( 'The %1$sElementor - Header Footer and Blocks%2$s plugin is not working because you are using old version of %1$sElementor%2$s plugin.', 'header-footer-elementor' ), '<strong>', '</strong>' );
+		$message = sprintf( __( 'The %1$sElementor - Header Footer and Blocks%2$s plugin has stopped working because you are using an older version of %1$sElementor%2$s plugin.', 'header-footer-elementor' ), '<strong>', '</strong>' );
 
 		$plugin = 'elementor/elementor.php';
 

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -59,7 +59,6 @@ class Header_Footer_Elementor {
 
 		if ( ( ! $is_elementor_callable ) || $is_elementor_outdated ) {
 			$this->elementor_not_available( $is_elementor_callable, $is_elementor_outdated );
-			return;
 		}
 
 		if ( $is_elementor_callable ) {
@@ -246,7 +245,7 @@ class Header_Footer_Elementor {
 			$button_label = __( 'Install Elementor', 'header-footer-elementor' );
 		}
 
-		$button = '<p><a href="' . $action_url . '" class="button-primary">' . $button_label . '</a></p><p></p>';
+		$button = '<p><a href="' . esc_url( $action_url ) . '" class="button-primary">' . esc_html( $button_label ) . '</a></p><p></p>';
 
 		printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
 	}
@@ -279,7 +278,7 @@ class Header_Footer_Elementor {
 			$button_label = __( 'Install Elementor', 'header-footer-elementor' );
 		}
 
-		$button = '<p><a href="' . $action_url . '" class="button-primary">' . $button_label . '</a></p><p></p>';
+		$button = '<p><a href="' . esc_url( $action_url ) . '" class="button-primary">' . esc_html( $button_label ) . '</a></p><p></p>';
 
 		printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
 	}

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -57,7 +57,7 @@ class Header_Footer_Elementor {
 
 		$is_elementor_outdated = ( defined( 'ELEMENTOR_VERSION' ) && ( ! version_compare( ELEMENTOR_VERSION, $required_elementor_version, '>=' ) ) ) ? true : false;
 
-		if( ( ! $is_elementor_callable ) || $is_elementor_outdated ) {
+		if ( ( ! $is_elementor_callable ) || $is_elementor_outdated ) {
 			$this->elementor_not_available( $is_elementor_callable, $is_elementor_outdated );
 			return;
 		}
@@ -199,13 +199,13 @@ class Header_Footer_Elementor {
 	 * Prints the admin notics when Elementor is not installed or activated or version outdated.
 	 */
 	public function elementor_not_available( $is_elementor_callable, $is_elementor_outdated ) {
-		
+
 		if ( ( ! did_action( 'elementor/loaded' ) ) || ( ! $is_elementor_callable ) ) {
 			add_action( 'admin_notices', [ $this, 'elementor_not_installed_activated' ] );
 			add_action( 'network_admin_notices', [ $this, 'elementor_not_installed_activated' ] );
 			return;
 		}
-		
+
 		if ( $is_elementor_outdated ) {
 			add_action( 'admin_notices', [ $this, 'elementor_outdated' ] );
 			add_action( 'network_admin_notices', [ $this, 'elementor_outdated' ] );
@@ -247,7 +247,7 @@ class Header_Footer_Elementor {
 		printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
 	}
 
-	
+
 	/**
 	 * Prints the admin notics when Elementor version is outdated.
 	 */

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -55,14 +55,14 @@ class Header_Footer_Elementor {
 
 		$required_elementor_version = '3.1.0';
 
-		$is_elementor_outdated = ( defined( 'ELEMENTOR_VERSION' ) && ( ! version_compare( ELEMENTOR_VERSION, $required_elementor_version, '>=' ) ) ) ? true : false;
+		$is_elementor_outdated = ( $is_elementor_callable && ( ! version_compare( ELEMENTOR_VERSION, $required_elementor_version, '>=' ) ) ) ? true : false;
 
 		if ( ( ! $is_elementor_callable ) || $is_elementor_outdated ) {
 			$this->elementor_not_available( $is_elementor_callable, $is_elementor_outdated );
 			return;
 		}
 
-		if ( defined( 'ELEMENTOR_VERSION' ) && is_callable( 'Elementor\Plugin::instance' ) ) {
+		if ( $is_elementor_callable ) {
 			self::$elementor_instance = Elementor\Plugin::instance();
 
 			$this->includes();
@@ -197,6 +197,11 @@ class Header_Footer_Elementor {
 
 	/**
 	 * Prints the admin notics when Elementor is not installed or activated or version outdated.
+	 * 
+	 * @since x.x.x
+	 * @param  boolean $is_elementor_callable specifies if elementor is available.
+	 * @param  boolean $is_elementor_outdated specifies if elementor version is old.
+	 *
 	 */
 	public function elementor_not_available( $is_elementor_callable, $is_elementor_outdated ) {
 
@@ -246,7 +251,6 @@ class Header_Footer_Elementor {
 
 		printf( '<div class="%1$s"><p>%2$s</p>%3$s</div>', esc_attr( $class ), wp_kses_post( $message ), wp_kses_post( $button ) );
 	}
-
 
 	/**
 	 * Prints the admin notics when Elementor version is outdated.


### PR DESCRIPTION
### Description
Added a notice to check the Elementor version installed on site. Header footer and Elementor blocks plugin needs Elementor's minimum version 3.0.0

### Screenshots
https://share.getcloudapp.com/geubA60d

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
- Checkout to Elementor versions below than 3.0.0
- Check if the notice appears on plugins page
- Check if any error appears on site due to HFE
- Click on Update Elementor Now
- Check if notice disappears and also HFE works fine on site

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
