### PR TITLE
Fix: Navigation Menu - Last menu item with button alignment control not working with and without RTL plugin.

### DIFF
--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -135,13 +135,15 @@ div.hfe-nav-menu,
           -webkit-justify-content: flex-end;
           -moz-box-pack: end;
           justify-content: flex-end; }
-.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
+.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: right;
 }
-.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
+.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: left;
 }
-.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li .elementor-button-wrapper{
+.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: center;
 }
 .hfe-nav-menu__align-left .hfe-nav-menu {

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -135,14 +135,20 @@ div.hfe-nav-menu,
           -webkit-justify-content: flex-end;
           -moz-box-pack: end;
           justify-content: flex-end; }
+
+.hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
 .hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper,
 .rtl .hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: right;
 }
+.hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
+.rtl .hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
 .hfe-nav-menu__align-left .hfe-nav-menu__layout-vertical li.elementor-button-wrapper,
 .rtl .hfe-nav-menu__align-right .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: left;
 }
+.hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li.hfe-has-submenu .elementor-button-wrapper,
 .hfe-nav-menu__align-center .hfe-nav-menu__layout-vertical li.elementor-button-wrapper{
     text-align: center;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 = 1.5.9 = 
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
-- Fix: Navigation Menu - Alignment not working for last menu item button with RTL plugin.
+- Fix: Navigation Menu - Last menu item button alignment not working in RTL view.
 
 = 1.5.8 =
 - Fix: Hardened allowed options in the editor to enforce better security policies.

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 = 1.5.9 = 
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.
 - Fix: Navigation Menu - Last menu item button disappearing while switching from mobile to desktop. 
+- Fix: Navigation Menu - Alignment not working for last menu item button with RTL plugin.
 
 = 1.5.8 =
 - Fix: Hardened allowed options in the editor to enforce better security policies.


### PR DESCRIPTION
### Description
Navigation Menu - Alignment not working for Last menu item with button with and without RTL.

### Types of changes
- Bugfix.

### How has this been tested?
- Check the last menu item with button alignment with and without RTL.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
