### PR TITLE
Fix - Top distance option for dropdown adding a top margin to sub-menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 ## Changelog ##
+### 1.5.9.1 ###
+- Fix: Navigation Menu - Top distance option for dropdown adding a top margin to sub-menu.
+
 ### 1.5.9 ###
 - Improvement: Added notice to update Elementor to v3.0.0 or higher
 Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1392,7 +1392,7 @@ class Navigation_Menu extends Widget_Base {
 						],
 					],
 					'selectors' => [
-						'{{WRAPPER}} nav.hfe-nav-menu__layout-horizontal ul.sub-menu, {{WRAPPER}} nav.hfe-nav-menu__layout-expandible.menu-is-active' => 'margin-top: {{SIZE}}px;',
+						'{{WRAPPER}} nav.hfe-nav-menu__layout-expandible.menu-is-active' => 'margin-top: {{SIZE}}px;',
 						'{{WRAPPER}} .hfe-dropdown.menu-is-active' => 'margin-top: {{SIZE}}px;',
 					],
 					'condition' => [

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1392,7 +1392,7 @@ class Navigation_Menu extends Widget_Base {
 						],
 					],
 					'selectors' => [
-						'{{WRAPPER}} nav.hfe-nav-menu__layout-expandible.menu-is-active' => 'margin-top: {{SIZE}}px;',
+						'{{WRAPPER}} nav.hfe-nav-menu__layout-horizontal:not(.hfe-dropdown) ul.sub-menu, {{WRAPPER}} nav.hfe-nav-menu__layout-expandible.menu-is-active' => 'margin-top: {{SIZE}}px;',
 						'{{WRAPPER}} .hfe-dropdown.menu-is-active' => 'margin-top: {{SIZE}}px;',
 					],
 					'condition' => [

--- a/readme.txt
+++ b/readme.txt
@@ -137,7 +137,10 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor – Header, Footer & Blocks.
 
 == Changelog ==
-= 1.5.9 = 
+= 1.5.9.1 =
+- Fix: Navigation Menu - Top distance option for dropdown adding a top margin to sub-menu.
+
+= 1.5.9 =
 - Improvement: Added notice to update Elementor to v3.0.0 or higher
 Elementor has deprecated few functions and namespaces with its v3.0.0. Following Elementor, our plugin too deprecates similar functions and namespaces. You will now require the Elementor v3.0.0 or higher. 
 - Improvement: Elementor 3.2 Compatibility - Added Elementor Global Color and Typography scheme support.


### PR DESCRIPTION
### Description
Fixed - Top distance option for dropdown adding a top margin to sub-menu.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
1. Use the `master` branch.
2. Now Create a menu with some sub-menu items.
3. Drag n drop Navigation menu widget. Go to responsive mode. Go to **Styles** tab -> **Dropdown** -> **Top distance**. Adjust the top distance to and you will see distance above the dropdown and distance above the sub-menu also.
4. Now switch to the `nav-top-distance-issue` branch.
5. Now you will see distance only above dropdown and not above any sub-menu.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->