### PR TITLE
Fix - Border in dropdown is also added to the icon.

### DIFF
--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1268,10 +1268,11 @@ class Navigation_Menu extends Widget_Base {
 				Group_Control_Border::get_type(),
 				[
 					'name'     => 'dropdown_border',
-					'selector' => '{{WRAPPER}} nav.hfe-nav-menu__layout-horizontal .sub-menu, 
+					'selector' => '{{WRAPPER}} nav.hfe-nav-menu__layout-horizontal .sub-menu,
 							{{WRAPPER}} nav:not(.hfe-nav-menu__layout-horizontal) .sub-menu.sub-menu-open,
-							{{WRAPPER}} nav.hfe-dropdown,
-						 	{{WRAPPER}} nav.hfe-dropdown-expandible',
+							{{WRAPPER}} nav.hfe-dropdown .hfe-nav-menu,
+						 	{{WRAPPER}} nav.hfe-dropdown-expandible .hfe-nav-menu,
+						 	{{WRAPPER}} .hfe-flyout-wrapper .hfe-flyout-container .hfe-nav-menu',
 				]
 			);
 


### PR DESCRIPTION
### Description
Fixed - Border in dropdown is also added to the icon.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
1. Use the `master` branch.
2. Drag n drop Navigation menu widget. Go to responsive mode.
3. Go to **Styles** tab -> **Dropdown** -> **Border Type**. Select border solid or any other and set width 20px, you will see space below the hamburger menu icon getting added.
4. Now switch to `nav-border-issue` branch.
5. Now you will see there will be no space below the hamburger menu icon

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
