### PR TITLE
Fix: Footer placed in the header or content area

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 ## Changelog ##
+### 1.6.1 ###
+- Fix: Footer placement issue.
+
 ### 1.6.0 ###
 - New: Added Email Subscription and About Us section on the settings page.
 - New: Renamed the plugin to Elementor Header & Footer Builder.

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 1.6.0
+ * Version: 1.6.1
  * Elementor tested up to: 3.2.5
  * Elementor Pro tested up to: 3.3.1
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.6.0' );
+define( 'HFE_VER', '1.6.1' );
 define( 'HFE_FILE', __FILE__ );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -86,6 +86,7 @@ class Header_Footer_Elementor {
 				require HFE_DIR . 'themes/hello-elementor/class-hfe-hello-elementor-compat.php';
 			} else {
 				add_filter( 'hfe_settings_tabs', [ $this, 'setup_unsupported_theme' ] );
+				add_action( 'init', [ $this, 'setup_fallback_support' ] );
 			}
 
 			if ( 'yes' === get_option( 'hfe_plugin_is_activated' ) ) {
@@ -479,6 +480,26 @@ class Header_Footer_Elementor {
 			];
 		}
 		return $hfe_settings_tabs;
+	}
+
+	/**
+	 * Add support for theme if the current theme does add support for 'header-footer-elementor'
+	 *
+	 * @since  1.6.1
+	 */
+	public function setup_fallback_support() {
+		
+		if ( ! current_theme_supports( 'header-footer-elementor' ) ) {
+			$hfe_compatibility_option = get_option( 'hfe_compatibility_option', '1' );
+
+			if ( '1' === $hfe_compatibility_option ) {
+				if ( ! class_exists( 'HFE_Default_Compat' ) ) {
+					require_once HFE_DIR . 'themes/default/class-hfe-default-compat.php';
+				}
+			} elseif ( '2' === $hfe_compatibility_option ) {
+				require HFE_DIR . 'themes/default/class-global-theme-compatibility.php';
+			}
+		}
 	}
 
 	/**

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -488,7 +488,7 @@ class Header_Footer_Elementor {
 	 * @since  1.6.1
 	 */
 	public function setup_fallback_support() {
-		
+
 		if ( ! current_theme_supports( 'header-footer-elementor' ) ) {
 			$hfe_compatibility_option = get_option( 'hfe_compatibility_option', '1' );
 

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -209,24 +209,6 @@ class HFE_Settings_Page {
 	}
 
 	/**
-	 * Setup Theme Support.
-	 *
-	 * @since 1.2.0
-	 * @return void
-	 */
-	public function setup_fallback_support() {
-		$hfe_compatibility_option = get_option( 'hfe_compatibility_option', '1' );
-
-		if ( '1' === $hfe_compatibility_option ) {
-			if ( ! class_exists( 'HFE_Default_Compat' ) ) {
-				require_once HFE_DIR . 'themes/default/class-hfe-default-compat.php';
-			}
-		} elseif ( '2' === $hfe_compatibility_option ) {
-			require HFE_DIR . 'themes/default/class-global-theme-compatibility.php';
-		}
-	}
-
-	/**
 	 * Settings page.
 	 *
 	 * Call back function for add submenu page function.

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -23,7 +23,6 @@ class HFE_Settings_Page {
 	 * @since 1.6.0
 	 */
 	public function __construct() {
-		$this->setup_fallback_support();
 		add_action( 'admin_head', [ $this, 'hfe_global_css' ] );
 		add_action( 'admin_menu', [ $this, 'hfe_register_settings_page' ] );
 		add_action( 'admin_init', [ $this, 'hfe_admin_init' ] );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 == Changelog ==
+= 1.6.1 =
+- Fix: Footer placement issue.
+
 = 1.6.0 =
 - New: Added Email Subscription and About Us section on the settings page.
 - New: Renamed the plugin to Elementor Header & Footer Builder.


### PR DESCRIPTION
### Description
Footer is getting placed in the header or content area.

### Screenshots
N/A

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- Test Footer working fine after checking out to this branch
- Test with these themes - 
    - Genesis
    - Astra
    - beaver builder theme
   - generate press
   - OceanWP
   - StoreFront
   - Hello Elementor
- Check if the Theme support tab on the settings page is displaying correctly for any theme apart from the listed above like twenty twenty-one theme
- Test header, before footer and blocks option too

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
