### PR TITLE
Improvement - Added Gradient color support to Search widget button

### DIFF
--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -663,19 +663,7 @@ class Search_Button extends Widget_Base {
 				],
 			]
 		);
-
-		// $this->add_control(
-		// 	'button_background_color',
-		// 	[
-		// 		'label'     => __( 'Background Color', 'header-footer-elementor' ),
-		// 		'type'      => Controls_Manager::COLOR,
-		// 		'default'   => '#818a91',
-		// 		'selectors' => [
-		// 			'{{WRAPPER}} .hfe-search-submit' => 'background-color: {{VALUE}}',
-		// 		],
-		// 	]
-		// );
-
+		
 		$this->add_group_control(
 			Group_Control_Background::get_type(),
 			[
@@ -687,6 +675,9 @@ class Search_Button extends Widget_Base {
 				'fields_options' => [
 					'background' => [
 						'default' => 'classic',
+					],
+					'color' => [
+						'default' => '#818a91',
 					],
 				],
 			]

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -664,14 +664,30 @@ class Search_Button extends Widget_Base {
 			]
 		);
 
-		$this->add_control(
-			'button_background_color',
+		// $this->add_control(
+		// 	'button_background_color',
+		// 	[
+		// 		'label'     => __( 'Background Color', 'header-footer-elementor' ),
+		// 		'type'      => Controls_Manager::COLOR,
+		// 		'default'   => '#818a91',
+		// 		'selectors' => [
+		// 			'{{WRAPPER}} .hfe-search-submit' => 'background-color: {{VALUE}}',
+		// 		],
+		// 	]
+		// );
+
+		$this->add_group_control(
+			Group_Control_Background::get_type(),
 			[
-				'label'     => __( 'Background Color', 'header-footer-elementor' ),
-				'type'      => Controls_Manager::COLOR,
-				'default'   => '#818a91',
-				'selectors' => [
-					'{{WRAPPER}} .hfe-search-submit' => 'background-color: {{VALUE}}',
+				'name' => 'button_background',
+				'label' => __( 'Background', 'elementor' ),
+				'types' => [ 'classic', 'gradient' ],
+				'exclude' => [ 'image' ],
+				'selector' => '{{WRAPPER}} .hfe-search-submit',
+				'fields_options' => [
+					'background' => [
+						'default' => 'classic',
+					],
 				],
 			]
 		);
@@ -703,6 +719,23 @@ class Search_Button extends Widget_Base {
 				'type'      => Controls_Manager::COLOR,
 				'selectors' => [
 					'{{WRAPPER}} .hfe-search-submit:hover' => 'background-color: {{VALUE}}',
+				],
+				'condition'   => [
+					'button_background_color_hover!' => '',
+				],
+			]
+		);
+
+		$this->add_group_control(
+			Group_Control_Background::get_type(),
+			[
+				'name' => 'button_background_hover',
+				'label' => __( 'Background', 'elementor' ),
+				'types' => [ 'classic', 'gradient' ],
+				'exclude' => [ 'image' ],
+				'selector' => '{{WRAPPER}} .hfe-search-submit:hover',
+				'condition'   => [
+					'button_background_color_hover' => '',
 				],
 			]
 		);

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -663,20 +663,20 @@ class Search_Button extends Widget_Base {
 				],
 			]
 		);
-		
+
 		$this->add_group_control(
 			Group_Control_Background::get_type(),
 			[
-				'name' => 'button_background',
-				'label' => __( 'Background', 'elementor' ),
-				'types' => [ 'classic', 'gradient' ],
-				'exclude' => [ 'image' ],
-				'selector' => '{{WRAPPER}} .hfe-search-submit',
+				'name'           => 'button_background',
+				'label'          => __( 'Background', 'elementor' ),
+				'types'          => [ 'classic', 'gradient' ],
+				'exclude'        => [ 'image' ],
+				'selector'       => '{{WRAPPER}} .hfe-search-submit',
 				'fields_options' => [
 					'background' => [
 						'default' => 'classic',
 					],
-					'color' => [
+					'color'      => [
 						'default' => '#818a91',
 					],
 				],
@@ -711,7 +711,7 @@ class Search_Button extends Widget_Base {
 				'selectors' => [
 					'{{WRAPPER}} .hfe-search-submit:hover' => 'background-color: {{VALUE}}',
 				],
-				'condition'   => [
+				'condition' => [
 					'button_background_color_hover!' => '',
 				],
 			]
@@ -720,12 +720,12 @@ class Search_Button extends Widget_Base {
 		$this->add_group_control(
 			Group_Control_Background::get_type(),
 			[
-				'name' => 'button_background_hover',
-				'label' => __( 'Background', 'elementor' ),
-				'types' => [ 'classic', 'gradient' ],
-				'exclude' => [ 'image' ],
-				'selector' => '{{WRAPPER}} .hfe-search-submit:hover',
-				'condition'   => [
+				'name'      => 'button_background_hover',
+				'label'     => __( 'Background', 'elementor' ),
+				'types'     => [ 'classic', 'gradient' ],
+				'exclude'   => [ 'image' ],
+				'selector'  => '{{WRAPPER}} .hfe-search-submit:hover',
+				'condition' => [
 					'button_background_color_hover' => '',
 				],
 			]

--- a/readme.txt
+++ b/readme.txt
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 - Improvement: Copyright - Added custom link attributes support.
 - Improvement: Page Title - Added custom link attributes support.
 - Improvement: Retina Image - Added custom link attributes support.
-- Improvement: Search - Added gradient color support to search button.
+- Improvement: Search - Added gradient color support to the search button.
 - Improvement: Site Logo - Added custom link attributes support.
 - Improvement: Site Title - Added custom link attributes support.
 - Fix: Templates views section not displaying correctly and related code conflicting with Yoast SEO plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 == Changelog ==
+= 1.6.2 =
+- Improvement: Search - Added gradient color support to search button.
+
 = 1.6.1 =
 - Fix: Footer misplaced in the header or content area due to a bug introduced in v1.6.0.
 


### PR DESCRIPTION
### Description
 Added Gradient color support to Search widget button

### Screenshots
https://share.getcloudapp.com/qGu5x2Wr

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
Improvement (non-breaking change which adds functionality)
<!-- Breaking change -->

### How has this been tested?
- Check if the default color applies correctly.
- Test normal and hover background colors has backward compatibility
- Note - If hover bg color is already set then we do not show gradient option ( facing issues regarding backward compatibility if changed control  ) If gradient color option is empty we display gradient color option.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
