### PR TITLE
Fix: Templates views section not displaying correctly

### DIFF
--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -101,7 +101,7 @@ class HFE_Settings_Page {
 		$this->hfe_tabs();
 		$this->hfe_modal();
 		return $views;
-		
+
 	}
 
 	/**

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -99,18 +99,9 @@ class HFE_Settings_Page {
 	public function hfe_settings( $views ) {
 
 		$this->hfe_tabs();
-		$is_dismissed = [];
-		$is_dismissed = get_user_meta( get_current_user_id(), 'hfe-popup' );
-
-		$is_subscribed   = get_user_meta( get_current_user_ID(), 'hfe-subscribed' );
-		$subscribe_valid = ( is_array( $is_subscribed ) && isset( $is_subscribed[0] ) && 'yes' === $is_subscribed[0] ) ? 'yes' : false;
-
-		if ( ( ! empty( $is_dismissed ) && 'dismissed' === $is_dismissed[0] ) || 'yes' === $subscribe_valid ) {
-			return false;
-		} else {
-			$this->get_guide_modal();
-		}
+		$this->hfe_modal();
 		return $views;
+		
 	}
 
 	/**
@@ -236,6 +227,27 @@ class HFE_Settings_Page {
 
 			case 'default':
 				break;
+		}
+	}
+
+	/**
+	 * Settings page - load modal content.
+	 *
+	 * Call back function for add submenu page function.
+	 *
+	 * @since x.x.x
+	 */
+	public function hfe_modal() {
+		$is_dismissed = [];
+		$is_dismissed = get_user_meta( get_current_user_id(), 'hfe-popup' );
+
+		$is_subscribed   = get_user_meta( get_current_user_ID(), 'hfe-subscribed' );
+		$subscribe_valid = ( is_array( $is_subscribed ) && isset( $is_subscribed[0] ) && 'yes' === $is_subscribed[0] ) ? 'yes' : false;
+
+		if ( ( ! empty( $is_dismissed ) && 'dismissed' === $is_dismissed[0] ) || 'yes' === $subscribe_valid ) {
+			return false;
+		} else {
+			$this->get_guide_modal();
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,14 +138,12 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.6.2 = 
-- Improvement: Copyright - Added custom attributes support.
-- Improvement: Page Title - Added custom attributes support.
-- Improvement: Retina Image - Added custom attributes support.
-- Improvement: Site Logo - Added custom attributes support.
-- Improvement: Site Title - Added custom attributes support.
-
-= 1.6.1 =
-- Fix: Templates views section not displaying correctly.
+- Improvement: Copyright - Added custom link attributes support.
+- Improvement: Page Title - Added custom link attributes support.
+- Improvement: Retina Image - Added custom link attributes support.
+- Improvement: Site Logo - Added custom link attributes support.
+- Improvement: Site Title - Added custom link attributes support.
+- Fix: Templates views section not displaying correctly and related code conflicting with Yoast SEO plugin.
 
 = 1.6.1 =
 - Fix: Footer misplaced in the header or content area due to a bug introduced in v1.6.0.

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 = 1.6.1 =
+- Fix: Templates views section not displaying correctly.
+
+= 1.6.1 =
 - Fix: Footer misplaced in the header or content area due to a bug introduced in v1.6.0.
 
 = 1.6.0 =


### PR DESCRIPTION
### Description
The templates views section not displaying correctly and similar code was leading conflict with Yoast SEO plugin.

### Screenshots
https://share.getcloudapp.com/E0uAZdOr

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- Check if Yoast SEO bugs get fixed
- Check if views options display correctly - https://share.getcloudapp.com/E0uAZdOr
- Check if Subscribe Popup displays correctly.
- Check other tabs like About Us and check if it displays correctly

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
