### PR TITLE
Hide counter when hide empty option is ON

### DIFF
--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -1737,7 +1737,7 @@ div.hfe-nav-menu,
     font-weight: normal; 
 }
 
-.hfe-menu-cart--empty-indicator-hide .hfe-menu-cart__toggle .elementor-button .elementor-button-icon[data-counter]:before {
+.hfe-menu-cart--empty-indicator-hide .hfe-menu-cart__toggle .elementor-button .elementor-button-icon[data-counter="0"]:before {
     content: none;
     display: none; 
 }


### PR DESCRIPTION
### Description

- In this PR
    Previously, if you enable the hide empty option it will not show you the count of the products in the cart even when the cart
    is not empty.
    but now only when the cart is empty it will not be showing the count.


### Screenshots

Before
https://d.pr/v/216Cat

After
https://d.pr/v/X6cszl



### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

1. Cart widget -> Content -> Menu Cart -> Type -> Custom -> Hide Empty.
2. When the cart is empty it will not show you the count of the cart items.

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
