### PR TITLE
Aria-label rule accessibility for navigation bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
+= 1.6.14 =
+- Fix: Navigation Menu - Accessibility error corrected for [aria-hidden="true"] label.
+
 ### 1.6.13 ###
 - Compatibility with Elementor version 3.7.2 and Elementor Pro version 3.7.3.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 
 = 1.6.14 =
-- Fix: Navigation Menu - Accessibility error corrected for [aria-hidden="true"] label.
+- Fix: Navigation Menu - Accessibility error corrected for [aria-hidden="true"] attribute.
 
 ### 1.6.13 ###
 - Compatibility with Elementor version 3.7.2 and Elementor Pro version 3.7.3.

--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -167,8 +167,16 @@
   		$scope.find( '.parent-has-child .hfe-has-submenu-container a').attr( 'aria-haspopup', 'true' );
   		$scope.find( '.parent-has-child .hfe-has-submenu-container a').attr( 'aria-expanded', 'false' );
 
-  		$scope.find( '.hfe-nav-menu__toggle').attr( 'aria-haspopup', 'true' );
-  		$scope.find( '.hfe-nav-menu__toggle').attr( 'aria-expanded', 'false' );
+		var hef_navmenu_toggle = $scope.find( '.hfe-nav-menu__toggle' );
+		hef_navmenu_toggle.attr( 'aria-haspopup', 'true' );
+		hef_navmenu_toggle.attr( 'aria-expanded', 'false' );
+
+		if ( window.matchMedia( "( max-width: 1024px )" ).matches && $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') ) {
+			hef_navmenu_toggle.find('i').attr('aria-hidden', 'false');
+		}
+		if ( window.matchMedia( "( max-width: 1024px )" ).matches && $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile') ) {
+			hef_navmenu_toggle.find('i').attr('aria-hidden', 'false');
+		}
 
   		// End of accessibility functions
 

--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -174,7 +174,7 @@
 		if ( window.matchMedia( "( max-width: 1024px )" ).matches && $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') ) {
 			hef_navmenu_toggle.find('i').attr('aria-hidden', 'false');
 		}
-		if ( window.matchMedia( "( max-width: 1024px )" ).matches && $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile') ) {
+		if ( window.matchMedia( "( max-width: 768px )" ).matches && $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-mobile') ) {
 			hef_navmenu_toggle.find('i').attr('aria-hidden', 'false');
 		}
 

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -2017,7 +2017,8 @@ class Navigation_Menu extends Widget_Base {
 
 			?>
 			<div <?php echo $this->get_render_attribute_string( 'hfe-main-menu' ); ?>>
-				<div class="hfe-nav-menu__toggle elementor-clickable">
+				<div role="button" class="hfe-nav-menu__toggle elementor-clickable">
+					<span class="screen-reader-text">Menu</span>
 					<div class="hfe-nav-menu-icon">
 						<?php echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.6.14 =
+- Fix: Navigation Menu - Accessibility error corrected for [aria-hidden="true"] label.
+
 = 1.6.13 =
 - Compatibility with Elementor version 3.7.2 and Elementor Pro version 3.7.3.
 

--- a/readme.txt
+++ b/readme.txt
@@ -139,7 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.6.14 =
-- Fix: Navigation Menu - Accessibility error corrected for [aria-hidden="true"] label.
+- Fix: Navigation Menu - Accessibility error corrected for [aria-hidden="true"] attribute.
 
 = 1.6.13 =
 - Compatibility with Elementor version 3.7.2 and Elementor Pro version 3.7.3.


### PR DESCRIPTION
### Description
Fixed accessibility error logs for navigation bar.

### Screenshots
https://i.imgur.com/XVYjHjM.png
### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- Drag/Drop navigation menu in a section/container
- Check on mobile menu for lighthouse accessibility

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
