### PR TITLE
EPS-114: Polylang issues with custom header footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 ## Changelog ##
+### 1.6.15 ###
+- Fix: Polylang plugin language causes conflicts when set up with a custom Header Footer.
 
 ### 1.6.14 ###
 - Improvement: Compatibility with Elementor version 3.13 and Elementor Pro version 3.13

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -566,7 +566,13 @@ class Header_Footer_Elementor {
 
 		foreach ( $hfe_templates as $template ) {
 			if ( get_post_meta( absint( $template['id'] ), 'ehf_template_type', true ) === $type ) {
-				return $template['id'];
+				if ( function_exists( 'pll_current_language' ) ) {
+					if ( pll_current_language( 'slug' ) == pll_get_post_language( $template['id'], 'slug' ) ) {
+						return $template['id'];
+					}
+				} else {
+					return $template['id'];
+				}
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,8 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 == Changelog ==
+= 1.6.15 =
+- Fix: Polylang plugin language causes conflicts when set up with a custom Header Footer.
 
 = 1.6.14 =
 - Improvement: Compatibility with Elementor version 3.13 and Elementor Pro version 3.13


### PR DESCRIPTION
### Description
Header/Footer builder in combination with Polylang when set up with a custom header/footer for languages is conflicting.

### Screenshots
https://i.imgur.com/FI9UmWK.png
https://i.imgur.com/rBwjWcI.png
After fix : https://i.imgur.com/cpWwDsC.png
### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
