### PR TITLE
fix: site logo element's align icons

### DIFF
--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -163,15 +163,15 @@ class Site_Logo extends Widget_Base {
 				'options'            => [
 					'left'   => [
 						'title' => __( 'Left', 'header-footer-elementor' ),
-						'icon'  => 'fa fa-align-left',
+						'icon'  => 'eicon-text-align-left',
 					],
 					'center' => [
 						'title' => __( 'Center', 'header-footer-elementor' ),
-						'icon'  => 'fa fa-align-center',
+						'icon'  => 'eicon-text-align-center',
 					],
 					'right'  => [
 						'title' => __( 'Right', 'header-footer-elementor' ),
-						'icon'  => 'fa fa-align-right',
+						'icon'  => 'eicon-text-align-right',
 					],
 				],
 				'default'            => 'center',


### PR DESCRIPTION
### Description
When Site Logo element is placed inside Elementor editor alone without any element on that page or anything loading FontAwesome library, the align icons will not render and this element don't have any editor icon control so it won't load the Fontawesome itself either. So we should replace Fontawesome icons with Elementor icons.

### Screenshots
![Screenshot 2023-06-14 162230](https://github.com/brainstormforce/header-footer-elementor/assets/98876719/110ed444-7f56-4c22-ba50-e0599e3a926e)

### Types of changes
Replacing Fontawesome icons with  Elementor's icons
