### PR TITLE
EPS-192: Nav menu: html validation error tabindex inside element with the attribute role=button

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 ### 1.6.15 ###
 - Improvement: Added WPML support.
+- Fix: Navigation Menu - HTML validation error on mobile layout related to tabindex inside elements with attribute [role="button"].
 - Fix: Polylang plugin language causes conflicts when set up with a custom Header Footer.
 
 ### 1.6.14 ###

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1943,7 +1943,7 @@ class Navigation_Menu extends Widget_Base {
 
 			?>
 			<div class="hfe-nav-menu__toggle elementor-clickable hfe-flyout-trigger" tabindex="0">
-					<div class="hfe-nav-menu-icon">
+					<div class="hfe-nav-menu-icon test1234">
 						<?php echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 				</div>
@@ -2020,7 +2020,9 @@ class Navigation_Menu extends Widget_Base {
 				<div role="button" class="hfe-nav-menu__toggle elementor-clickable">
 					<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'header-footer-elementor' ); ?></span>
 					<div class="hfe-nav-menu-icon">
-						<?php echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php
+						$menu_close_icons[0] = str_replace('tabindex="0"', '', $menu_close_icons[0]); 
+						echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 				</div>
 				<nav <?php echo $this->get_render_attribute_string( 'hfe-nav-menu' ); ?>><?php echo $menu_html; ?></nav>

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1943,7 +1943,7 @@ class Navigation_Menu extends Widget_Base {
 
 			?>
 			<div class="hfe-nav-menu__toggle elementor-clickable hfe-flyout-trigger" tabindex="0">
-					<div class="hfe-nav-menu-icon test1234">
+					<div class="hfe-nav-menu-icon">
 						<?php echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 				</div>
@@ -2021,8 +2021,9 @@ class Navigation_Menu extends Widget_Base {
 					<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'header-footer-elementor' ); ?></span>
 					<div class="hfe-nav-menu-icon">
 						<?php
-						$menu_close_icons[0] = str_replace('tabindex="0"', '', $menu_close_icons[0]); 
-						echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						$menu_close_icons[0] = str_replace( 'tabindex="0"', '', $menu_close_icons[0] );
+						echo isset( $menu_close_icons[0] ) ? $menu_close_icons[0] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
 					</div>
 				</div>
 				<nav <?php echo $this->get_render_attribute_string( 'hfe-nav-menu' ); ?>><?php echo $menu_html; ?></nav>

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 = 1.6.15 =
 - Improvement: Added WPML support.
+- Fix: Navigation Menu - HTML validation error on mobile layout related to tabindex inside elements with attribute [role="button"].
 - Fix: Polylang plugin language causes conflicts when set up with a custom Header Footer.
 
 = 1.6.14 =


### PR DESCRIPTION
### Description
For navigation menu the HTML validation error tab index inside element with the attribute role=button

### Screenshots
https://i.imgur.com/f2ZTTyJ.png

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- Drag and Drop the navigation menu Go in 
- layouts and change the breakpointt to mobile_scroll u will get the error as seen in screenshot

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
