### PR TITLE
Fix: Header and Footer layout broken after last update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.4  
 **Requires PHP:** 5.4  
 **Tested up to:** 6.4.1  
-**Stable tag:** 1.6.18  
+**Stable tag:** 1.6.19  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -139,6 +139,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 ## Changelog ##
+
+### 1.6.19 ###
+- Fix: Header and Footer layout broken after last update.
 
 ### 1.6.18 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.18 version.

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 1.6.18
+ * Version: 1.6.19
  * Elementor tested up to: 3.18
  * Elementor Pro tested up to: 3.18
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.6.18' );
+define( 'HFE_VER', '1.6.19' );
 define( 'HFE_FILE', __FILE__ );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -508,7 +508,7 @@ class Header_Footer_Elementor {
 	 */
 	public static function get_header_content() {
 		$header_content = self::$elementor_instance->frontend->get_builder_content_for_display( get_hfe_header_id() );
-		echo $header_content;
+		echo $header_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -516,7 +516,7 @@ class Header_Footer_Elementor {
 	 */
 	public static function get_footer_content() {
 		echo "<div class='footer-width-fixer'>";
-		echo self::$elementor_instance->frontend->get_builder_content_for_display( get_hfe_footer_id() );
+		echo self::$elementor_instance->frontend->get_builder_content_for_display( get_hfe_footer_id() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '</div>';
 	}
 
@@ -525,7 +525,7 @@ class Header_Footer_Elementor {
 	 */
 	public static function get_before_footer_content() {
 		echo "<div class='footer-width-fixer'>";
-		echo self::$elementor_instance->frontend->get_builder_content_for_display( hfe_get_before_footer_id() );
+		echo self::$elementor_instance->frontend->get_builder_content_for_display( hfe_get_before_footer_id() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '</div>';
 	}
 

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -155,7 +155,7 @@ class Header_Footer_Elementor {
 				'type'                       => '',
 				'message'                    => sprintf(
 					'<div class="notice-image">
-						<img src="%1$s" class="custom-logo" alt="Sidebar Manager" itemprop="logo"></div> 
+						<img src="%1$s" class="custom-logo" alt="Sidebar Manager" itemprop="logo"></div>
 						<div class="notice-content">
 							<div class="notice-heading">
 								%2$s
@@ -508,7 +508,7 @@ class Header_Footer_Elementor {
 	 */
 	public static function get_header_content() {
 		$header_content = self::$elementor_instance->frontend->get_builder_content_for_display( get_hfe_header_id() );
-		echo wp_kses_post( $header_content );
+		echo $header_content;
 	}
 
 	/**
@@ -516,7 +516,7 @@ class Header_Footer_Elementor {
 	 */
 	public static function get_footer_content() {
 		echo "<div class='footer-width-fixer'>";
-		echo wp_kses_post( self::$elementor_instance->frontend->get_builder_content_for_display( get_hfe_footer_id() ) );
+		echo self::$elementor_instance->frontend->get_builder_content_for_display( get_hfe_footer_id() );
 		echo '</div>';
 	}
 
@@ -525,7 +525,7 @@ class Header_Footer_Elementor {
 	 */
 	public static function get_before_footer_content() {
 		echo "<div class='footer-width-fixer'>";
-		echo wp_kses_post( self::$elementor_instance->frontend->get_builder_content_for_display( hfe_get_before_footer_id() ) );
+		echo self::$elementor_instance->frontend->get_builder_content_for_display( hfe_get_before_footer_id() );
 		echo '</div>';
 	}
 

--- a/inc/widgets-manager/widgets/class-cart.php
+++ b/inc/widgets-manager/widgets/class-cart.php
@@ -643,7 +643,7 @@ class Cart extends Widget_Base {
 						<a id="hfe-menu-cart__toggle_button" href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="elementor-button hfe-cart-container">
 							<?php if ( null !== WC()->cart ) { ?>
 								<span class="elementor-button-text hfe-subtotal">
-									<?php echo wp_kses_post( WC()->cart->get_cart_subtotal() ); ?>
+									<?php echo WC()->cart->get_cart_subtotal(); ?>
 								</span>
 							<?php } ?>
 							<span class="elementor-button-icon" data-counter="<?php echo ( null !== WC()->cart ) ? esc_attr( WC()->cart->get_cart_contents_count() ) : ''; ?>">

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -2016,7 +2016,7 @@ class Navigation_Menu extends Widget_Base {
 			$this->add_render_attribute( 'hfe-nav-menu', 'data-full-width', $settings['full_width_dropdown'] );
 
 			?>
-			<div <?php echo wp_kses_post( $this->get_render_attribute_string( 'hfe-main-menu' ) ); ?>>
+			<div <?php echo $this->get_render_attribute_string( 'hfe-main-menu' ); ?>>
 				<div role="button" class="hfe-nav-menu__toggle elementor-clickable">
 					<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'header-footer-elementor' ); ?></span>
 					<div class="hfe-nav-menu-icon">
@@ -2026,7 +2026,7 @@ class Navigation_Menu extends Widget_Base {
 						?>
 					</div>
 				</div>
-				<nav <?php echo wp_kses_post( $this->get_render_attribute_string( 'hfe-nav-menu' ) ); ?>><?php echo wp_kses_post( $menu_html ); ?></nav>
+				<nav <?php echo $this->get_render_attribute_string( 'hfe-nav-menu' ); ?>><?php echo $menu_html; ?></nav>
 			</div>
 			<?php
 		}

--- a/inc/widgets-manager/widgets/class-search-button.php
+++ b/inc/widgets-manager/widgets/class-search-button.php
@@ -982,18 +982,18 @@ class Search_Button extends Widget_Base {
 		<form class="hfe-search-button-wrapper" role="search" action="<?php echo esc_url( home_url() ); ?>" method="get">
 			<?php if ( 'icon' === $settings['layout'] ) { ?>
 			<div class = "hfe-search-icon-toggle">
-				<input <?php echo wp_kses_post( $this->get_render_attribute_string( 'input' ) ); ?>>
+				<input <?php echo $this->get_render_attribute_string( 'input' ); ?>>
 				<i class="fas fa-search" aria-hidden="true"></i>
 			</div>
 			<?php } else { ?>
-			<div <?php echo wp_kses_post( $this->get_render_attribute_string( 'container' ) ); ?>>
+			<div <?php echo $this->get_render_attribute_string( 'container' ); ?>>
 				<?php if ( 'text' === $settings['layout'] ) { ?>
-					<input <?php echo wp_kses_post( $this->get_render_attribute_string( 'input' ) ); ?>>
+					<input <?php echo $this->get_render_attribute_string( 'input' ); ?>>
 						<button id="clear" type="reset">
 							<i class="fas fa-times clearable__clear" aria-hidden="true"></i>
 						</button>
 				<?php } else { ?>
-					<input <?php echo wp_kses_post( $this->get_render_attribute_string( 'input' ) ); ?>>
+					<input <?php echo $this->get_render_attribute_string( 'input' ); ?>>
 					<button id="clear-with-button" type="reset">
 						<i class="fas fa-times" aria-hidden="true"></i>
 					</button>

--- a/inc/widgets-manager/widgets/class-site-logo.php
+++ b/inc/widgets-manager/widgets/class-site-logo.php
@@ -756,7 +756,7 @@ class Site_Logo extends Widget_Base {
 						$class = 'elementor-non-clickable';
 					}
 					?>
-				<a data-elementor-open-lightbox="<?php echo esc_attr( $settings['open_lightbox'] ); ?>"  class='<?php echo  esc_attr( $class ); ?>' <?php echo wp_kses_post( $this->get_render_attribute_string( 'link' ) ); ?>>
+				<a data-elementor-open-lightbox="<?php echo esc_attr( $settings['open_lightbox'] ); ?>"  class='<?php echo  esc_attr( $class ); ?>' <?php echo $this->get_render_attribute_string( 'link' ); ?>>
 		<?php endif; ?>
 		<?php
 		if ( empty( $site_image ) ) {

--- a/languages/header-footer-elementor.pot
+++ b/languages/header-footer-elementor.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the Elementor Header & Footer Builder package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Elementor Header & Footer Builder 1.6.18\n"
+"Project-Id-Version: Elementor Header & Footer Builder 1.6.19\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/header-footer-elementor\n"
-"POT-Creation-Date: 2023-11-30 07:08:53+00:00\n"
+"POT-Creation-Date: 2023-12-01 04:05:32+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
 Tested up to: 6.4.1
-Stable tag: 1.6.18
+Stable tag: 1.6.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -139,6 +139,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 == Changelog ==
+
+= 1.6.19 =
+- Fix: Header and Footer layout broken after last update.
 
 = 1.6.18 =
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.18 version.


### PR DESCRIPTION
### Description
- Fix: Header and Footer layout broken after last update.

### Screenshots
<!-- if applicable -->

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Tested header and footer layout on frontend

### Checklist:
- [x] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
