### PR TITLE
AST-3785 - Fix: Astra's theme name does not change when Astra is white-labeled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
+### 1.6.24 ###
+- Fix: White Label - Astra's theme name does not change when Astra is white-labeled. 
+
 ### 1.6.23 ###
 - Fix: This update addressed a security bug. Props to WordPress Plugin Review Team and Plugin Vulnerabilities Team for reporting it to our team. Please make sure you are using the latest version on your website.
 

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -706,6 +706,14 @@ class HFE_Settings_Page {
 	 */
 	protected function get_bsf_plugins() {
 
+		$theme_author = apply_filters(
+			'astra_theme_author',
+			array(
+				'theme_name'       => esc_html__( 'Astra Theme', 'header-footer-elementor' ),
+				'theme_author_url' => 'https://wpastra.com/',
+			)
+		);
+
 		$images_url = HFE_URL . 'assets/images/settings/';
 
 		return [
@@ -713,11 +721,11 @@ class HFE_Settings_Page {
 			'astra'                                     => [
 				'icon'    => $images_url . 'plugin-astra.png',
 				'type'    => 'theme',
-				'name'    => esc_html__( 'Astra Theme', 'header-footer-elementor' ),
-				'desc'    => esc_html__( 'Powering over 1+ Million websites, Astra is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ),
+				'name'    => $theme_author['theme_name'],
+				'desc'    => esc_html( sprintf( __( 'Powering over 1+ Million websites, %s is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ), esc_html( $theme_author['theme_name'] ) ) ),
 				'wporg'   => 'https://wordpress.org/themes/astra/',
 				'url'     => 'https://downloads.wordpress.org/theme/astra.zip',
-				'siteurl' => 'https://wpastra.com/',
+				'siteurl' => $theme_author['theme_author_url'],
 				'pro'     => false,
 				'slug'    => 'astra',
 			],

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -514,6 +514,11 @@ class HFE_Settings_Page {
 	 * @since 1.6.0
 	 */
 	protected function output_about_info() {
+
+		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
+
+		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : esc_html__( 'Astra Theme', 'header-footer-elementor' );
+
 		?>
 
 		<div class="hfe-admin-about-section hfe-admin-columns hfe-admin-about-us">
@@ -527,7 +532,7 @@ class HFE_Settings_Page {
 
 				<p><?php esc_html_e( 'Trusted by more than 1+ Million users, Elementor Header & Footer Builder is a modern way to build advanced navigation for your website.', 'header-footer-elementor' ); ?></p>
 
-				<p><?php esc_html_e( 'This plugin is brought to you by the same team behind the popular WordPress theme Astra and a series of Ultimate Addons plugins.', 'header-footer-elementor' ); ?></p>
+				<p><?php printf( esc_html__( 'This plugin is brought to you by the same team behind the popular WordPress theme %s and a series of Ultimate Addons plugins.', 'header-footer-elementor' ), esc_html( $theme_name ) ); ?>
 
 			</div>
 
@@ -706,26 +711,22 @@ class HFE_Settings_Page {
 	 */
 	protected function get_bsf_plugins() {
 
-		$theme_author = apply_filters(
-			'astra_theme_author',
-			array(
-				'theme_name'       => esc_html__( 'Astra Theme', 'header-footer-elementor' ),
-				'theme_author_url' => 'https://wpastra.com/',
-			)
-		);
+		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
+
+		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : esc_html__( 'Astra Theme', 'header-footer-elementor' );
 
 		$images_url = HFE_URL . 'assets/images/settings/';
 
 		return [
 
 			'astra'                                     => [
-				'icon'    => $images_url . 'plugin-astra.png',
+				'icon'    => ! empty( $white_labels['astra']['icon'] ) ? $white_labels['astra']['icon'] : $images_url . 'plugin-astra.png',
 				'type'    => 'theme',
-				'name'    => $theme_author['theme_name'],
-				'desc'    => esc_html( sprintf( __( 'Powering over 1+ Million websites, %s is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ), esc_html( $theme_author['theme_name'] ) ) ),
+				'name'    => ! empty( $theme_name ) ? $theme_name : esc_html__( 'Astra Theme', 'header-footer-elementor' ),
+				'desc'    => esc_html( sprintf( __( 'Powering over 1+ Million websites, %s is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ), esc_html( $theme_name ) ) ),
 				'wporg'   => 'https://wordpress.org/themes/astra/',
 				'url'     => 'https://downloads.wordpress.org/theme/astra.zip',
-				'siteurl' => $theme_author['theme_author_url'],
+				'siteurl' => ! empty( $white_labels['astra']['author_url'] ) ? $white_labels['astra']['author_url'] : 'https://wpastra.com/',
 				'pro'     => false,
 				'slug'    => 'astra',
 			],

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -361,7 +361,7 @@ class HFE_Settings_Page {
 		<div class="hfe-admin-about-section hfe-admin-columns hfe-admin-guide-section<?php echo esc_attr( $subscribe_flag ); ?>">
 
 			<div class="hfe-admin-column-50">
-				<div class="hfe-admin-about-section-column">					
+				<div class="hfe-admin-about-section-column">
 					<h2><?php esc_html_e( 'Create Impressive Header and Footer Designs', 'header-footer-elementor' ); ?></h2>
 					<p><?php esc_html_e( 'Elementor Header & Footer Builder plugin lets you build impactful navigation for your website very easily. Before we begin, we would like to know more about you. This will help us to serve you better.', 'header-footer-elementor' ); ?></p>
 				</div>
@@ -508,6 +508,12 @@ class HFE_Settings_Page {
 		$this->output_about_addons();
 	}
 
+	/**
+	 * Function for Astra Pro white labels with defaults.
+	 *
+	 * @since 1.6.24
+	 * @return array
+	 */
 	protected function get_white_label() {
 		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
 

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -508,6 +508,19 @@ class HFE_Settings_Page {
 		$this->output_about_addons();
 	}
 
+	protected function get_white_label() {
+		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
+
+		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : esc_html__( 'Astra', 'header-footer-elementor' );
+
+		return array(
+			'theme_name'  => $theme_name,
+			'description' => ! empty( $white_labels['astra']['description'] ) ? $white_labels['astra']['description'] : esc_html( sprintf( __( 'Powering over 1+ Million websites, %s is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ), esc_html( $theme_name ) ) ),
+			'theme_icon'  => ! empty( $white_labels['astra']['icon'] ) ? $white_labels['astra']['icon'] : '',
+			'author_url'  => ! empty( $white_labels['astra']['author_url'] ) ? $white_labels['astra']['author_url'] : 'https://wpastra.com/'
+		);
+	}
+
 	/**
 	 * Display the General Info section of About tab.
 	 *
@@ -515,9 +528,7 @@ class HFE_Settings_Page {
 	 */
 	protected function output_about_info() {
 
-		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
-
-		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : esc_html__( 'Astra Theme', 'header-footer-elementor' );
+		$white_labels = $this->get_white_label();
 
 		?>
 
@@ -532,7 +543,7 @@ class HFE_Settings_Page {
 
 				<p><?php esc_html_e( 'Trusted by more than 1+ Million users, Elementor Header & Footer Builder is a modern way to build advanced navigation for your website.', 'header-footer-elementor' ); ?></p>
 
-				<p><?php printf( esc_html__( 'This plugin is brought to you by the same team behind the popular WordPress theme %s and a series of Ultimate Addons plugins.', 'header-footer-elementor' ), esc_html( $theme_name ) ); ?>
+				<p><?php printf( esc_html__( 'This plugin is brought to you by the same team behind the popular WordPress theme %s and a series of Ultimate Addons plugins.', 'header-footer-elementor' ), esc_html( $white_labels['theme_name'] ) ); ?>
 
 			</div>
 
@@ -711,22 +722,20 @@ class HFE_Settings_Page {
 	 */
 	protected function get_bsf_plugins() {
 
-		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
-
-		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : esc_html__( 'Astra Theme', 'header-footer-elementor' );
+		$white_labels = $this->get_white_label();
 
 		$images_url = HFE_URL . 'assets/images/settings/';
 
 		return [
 
 			'astra'                                     => [
-				'icon'    => ! empty( $white_labels['astra']['icon'] ) ? $white_labels['astra']['icon'] : $images_url . 'plugin-astra.png',
+				'icon'    => ! empty( $white_labels['theme_icon'] ) ? $white_labels['theme_icon'] : $images_url . 'plugin-astra.png',
 				'type'    => 'theme',
-				'name'    => ! empty( $theme_name ) ? $theme_name : esc_html__( 'Astra Theme', 'header-footer-elementor' ),
-				'desc'    => esc_html( sprintf( __( 'Powering over 1+ Million websites, %s is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ), esc_html( $theme_name ) ) ),
+				'name'    => $white_labels['theme_name'],
+				'desc'    => $white_labels['description'],
 				'wporg'   => 'https://wordpress.org/themes/astra/',
 				'url'     => 'https://downloads.wordpress.org/theme/astra.zip',
-				'siteurl' => ! empty( $white_labels['astra']['author_url'] ) ? $white_labels['astra']['author_url'] : 'https://wpastra.com/',
+				'siteurl' => $white_labels['author_url'],
 				'pro'     => false,
 				'slug'    => 'astra',
 			],

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -523,7 +523,7 @@ class HFE_Settings_Page {
 			'theme_name'  => $theme_name,
 			'description' => ! empty( $white_labels['astra']['description'] ) ? $white_labels['astra']['description'] : esc_html( sprintf( __( 'Powering over 1+ Million websites, %s is loved for the fast performance and ease of use it offers. It is suitable for all kinds of websites like blogs, portfolios, business, and WooCommerce stores.', 'header-footer-elementor' ), esc_html( $theme_name ) ) ),
 			'theme_icon'  => ! empty( $white_labels['astra']['icon'] ) ? $white_labels['astra']['icon'] : '',
-			'author_url'  => ! empty( $white_labels['astra']['author_url'] ) ? $white_labels['astra']['author_url'] : 'https://wpastra.com/'
+			'author_url'  => ! empty( $white_labels['astra']['author_url'] ) ? $white_labels['astra']['author_url'] : 'https://wpastra.com/',
 		);
 	}
 

--- a/inc/class-hfe-settings-page.php
+++ b/inc/class-hfe-settings-page.php
@@ -517,7 +517,7 @@ class HFE_Settings_Page {
 	protected function get_white_label() {
 		$white_labels = is_callable( 'Astra_Admin_Helper::get_admin_settings_option' ) ? \Astra_Admin_Helper::get_admin_settings_option( '_astra_ext_white_label', true ) : array();
 
-		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : esc_html__( 'Astra', 'header-footer-elementor' );
+		$theme_name = ! empty( $white_labels['astra']['name'] ) ? $white_labels['astra']['name'] : 'Astra';
 
 		return array(
 			'theme_name'  => $theme_name,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.6.22",
+  "version": "1.6.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "header-footer-elementor",
-      "version": "1.6.22",
+      "version": "1.6.23",
       "license": "GPL-3.0",
       "dependencies": {
         "lodash": "^4.17.21"


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

When Astra is white-labeled there is an About Us page for the [Elementor Header & Footer Builder plugin](https://wordpress.org/plugins/header-footer-elementor/) that shows the active theme as Astra.

Screenshot: https://d.pr/i/g9JYud 

Steps to Replicate:

1. Enable the White Label Option of Astra and update the details.

2. Install [Elementor Header & Footer Builder plugin](https://wordpress.org/plugins/header-footer-elementor/)

3. Navigate to Apperance>>Elementor Header & Footer Builder>>About Us option, You will see the Active theme as Astra.

### Screenshots
<!-- if applicable -->
Before fix: https://d.pr/i/g9JYud 
After fix: https://www.awesomescreenshot.com/image/45393278?key=c6262de81678b1c71040b85203f4dc06

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
