### PR TITLE
EPS-385: Polylang Flag icon disappearing after the latest update 1.6.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
+### 1.6.24 ###
+Fix: Navigation Menu - Language switcher flags not displaying when using Polylang plugin. 
+
 ### 1.6.23 ###
 - Fix: This update addressed a security bug. Props to WordPress Plugin Review Team and Plugin Vulnerabilities Team for reporting it to our team. Please make sure you are using the latest version on your website.
 

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -1931,8 +1931,6 @@ class Navigation_Menu extends Widget_Base {
 			add_filter( 'nav_menu_li_values', [ $this, 'handle_li_values' ] );
 		}
 
-		$menu_html = wp_nav_menu( $args );
-
 		if ( 'flyout' === $settings['layout'] ) {
 
 			$this->add_render_attribute( 'hfe-flyout', 'class', 'hfe-flyout-wrapper' );
@@ -1953,7 +1951,7 @@ class Navigation_Menu extends Widget_Base {
 					<div id="hfe-flyout-content-id-<?php echo esc_attr( $this->get_id() ); ?>" class="hfe-side hfe-flyout-<?php echo esc_attr( $settings['flyout_layout'] ); ?> hfe-flyout-open" data-layout="<?php echo wp_kses_post( $settings['flyout_layout'] ); ?>" data-flyout-type="<?php echo wp_kses_post( $settings['flyout_type'] ); ?>">
 						<div class="hfe-flyout-content push">
 							<nav <?php $this->print_render_attribute_string( 'hfe-nav-menu' ); ?>>
-								<?php echo wp_kses_post( $menu_html ); ?>
+								<?php echo wp_nav_menu( $args ); ?>
 							</nav>
 							<div class="elementor-clickable hfe-flyout-close" tabindex="0">
 								<?php echo isset( $menu_close_icons[1] ) ? $menu_close_icons[1] : ''; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
@@ -2029,7 +2027,7 @@ class Navigation_Menu extends Widget_Base {
 					</div>
 				</div>
 				<nav <?php $this->print_render_attribute_string( 'hfe-nav-menu' ); ?>>
-					<?php echo ( $menu_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
+					<?php echo wp_nav_menu( $args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
 				</nav>
 			</div>
 			<?php

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -2029,7 +2029,7 @@ class Navigation_Menu extends Widget_Base {
 					</div>
 				</div>
 				<nav <?php $this->print_render_attribute_string( 'hfe-nav-menu' ); ?>>
-					<?php echo wp_kses_post( $menu_html ); ?>
+				<?php echo ( $menu_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
 				</nav>
 			</div>
 			<?php

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -2029,7 +2029,7 @@ class Navigation_Menu extends Widget_Base {
 					</div>
 				</div>
 				<nav <?php $this->print_render_attribute_string( 'hfe-nav-menu' ); ?>>
-				<?php echo ( $menu_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
+					<?php echo ( $menu_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
 				</nav>
 			</div>
 			<?php

--- a/inc/widgets-manager/widgets/class-navigation-menu.php
+++ b/inc/widgets-manager/widgets/class-navigation-menu.php
@@ -2027,7 +2027,7 @@ class Navigation_Menu extends Widget_Base {
 					</div>
 				</div>
 				<nav <?php $this->print_render_attribute_string( 'hfe-nav-menu' ); ?>>
-					<?php echo wp_nav_menu( $args ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> 
+					<?php echo wp_nav_menu( $args ); ?> 
 				</nav>
 			</div>
 			<?php

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.6.24 =
+Fix: Navigation Menu - Language switcher flags not displaying when using Polylang plugin. 
+
 = 1.6.23 =
 - Fix: This update addressed a security bug. Props to WordPress Plugin Review Team and Plugin Vulnerabilities Team for reporting it to our team. Please make sure you are using the latest version on your website.
 


### PR DESCRIPTION
### Description
Flag icon disappearing after the latest release. The icons seem to be broken.
They were working earlier with 1.6.22. Due to certain file change, the icons are broken.
### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Elementor, EHF and Polylang 
Just add a menu with language switcher, and check in UI
### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
