### PR TITLE
EPS-200 Fix: Automatic translation support for templates on Specific Pages / Posts / Taxonomies, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
-### 1.6.25 ###
+### 1.6.24.1 - Development Version ###
 - Fix: Automatic translation support for templates on Specific Pages / Posts / Taxonomies, etc.
 - Fix: Navigation Menu - Multistep submenu fails to display when a border radius is applied to dropdown.
 

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 1.6.23
+ * Version: 1.6.23.1
  * Elementor tested up to: 3.18
  * Elementor Pro tested up to: 3.18
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '1.6.23' );
+define( 'HFE_VER', '1.6.23.1' );
 define( 'HFE_FILE', __FILE__ );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );

--- a/inc/lib/target-rule/class-astra-target-rules-fields.php
+++ b/inc/lib/target-rule/class-astra-target-rules-fields.php
@@ -1266,6 +1266,18 @@ class Astra_Target_Rules_Fields {
 			$current_post_id   = false;
 			$q_obj             = get_queried_object();
 
+			$current_id      = esc_sql( get_the_id() );
+			// Find WPML Object ID for current page.
+			if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+				$default_lang = apply_filters( 'wpml_default_language', '' );
+				$current_lang = apply_filters( 'wpml_current_language', '' );
+
+				if( $default_lang !== $current_lang ) {
+					$current_post_type 	= get_post_type( $current_id );
+					$current_id = apply_filters( 'wpml_object_id', $current_id, $current_post_type, true, $default_lang );
+				}
+			}
+
 			$location = isset( $option['location'] ) ? esc_sql( $option['location'] ) : '';
 
 			$query = "SELECT p.ID, pm.meta_value FROM {$wpdb->postmeta} as pm
@@ -1308,14 +1320,12 @@ class Astra_Target_Rules_Fields {
 					$meta_args .= " OR pm.meta_value LIKE '%\"special-blog\"%'";
 					break;
 				case 'is_front_page':
-					$current_id      = esc_sql( get_the_id() );
 					$current_post_id = $current_id;
 					$meta_args      .= " OR pm.meta_value LIKE '%\"special-front\"%'";
 					$meta_args      .= " OR pm.meta_value LIKE '%\"{$current_post_type}|all\"%'";
 					$meta_args      .= " OR pm.meta_value LIKE '%\"post-{$current_id}\"%'";
 					break;
 				case 'is_singular':
-					$current_id      = esc_sql( get_the_id() );
 					$current_post_id = $current_id;
 					$meta_args      .= " OR pm.meta_value LIKE '%\"basic-singulars\"%'";
 					$meta_args      .= " OR pm.meta_value LIKE '%\"{$current_post_type}|all\"%'";
@@ -1333,7 +1343,7 @@ class Astra_Target_Rules_Fields {
 					$meta_args .= " OR pm.meta_value LIKE '%\"special-woo-shop\"%'";
 					break;
 				case '':
-					$current_post_id = get_the_id();
+					$current_post_id = $current_id;
 					break;
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-footer-elementor",
-  "version": "1.6.23",
+  "version": "1.6.23.1",
   "main": "Gruntfile.js",
   "author": "Nikhil Chavan",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
-### 1.6.25 ###
+### 1.6.24.1 - Development Version ###
 - Fix: Automatic translation support for templates on Specific Pages / Posts / Taxonomies, etc.
 - Fix: Navigation Menu - Multistep submenu fails to display when a border radius is applied to dropdown.
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Requires at least: 4.4
 Requires PHP: 5.4
 Tested up to: 6.4.1
-Stable tag: 1.6.23
+Stable tag: 1.6.23.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -139,6 +139,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 5. Default widgets available with Elementor Header & Footer Builder.
 
 == Changelog ==
+
+= 1.6.23.1 =
+- Fix: Automatic translation support for templates on Specific Pages / Posts / Taxonomies, etc.
 
 = 1.6.23 =
 - Fix: This update addressed a security bug. Props to WordPress Plugin Review Team and Plugin Vulnerabilities Team for reporting it to our team. Please make sure you are using the latest version on your website.


### PR DESCRIPTION
### Description
Fix: Automatic translation support for templates on Specific Pages / Posts / Taxonomies, etc.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
