### PR TITLE
EPS-538: Full width not working for container of nav menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 
 ### 1.6.37.1 ###
-- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width on smaller screens.
+- Improvement: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width on smaller screens.
 
 ### 1.6.37 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 
 ### 1.6.37.1 ###
-- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu is set to full width.
+- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu container is set to full width.
 
 ### 1.6.37 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 
 ### 1.6.37.1 ###
-- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu container is set to full width.
+- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width.
 
 ### 1.6.37 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 
 ### 1.6.37.1 ###
-- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width.
+- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width on smaller screens.
 
 ### 1.6.37 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
+### 1.6.37.1 ###
+- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu is set to full width.
+
 ### 1.6.37 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.
 

--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -626,8 +626,9 @@
 
 					$this.addClass( 'hfe-active-menu-full-width' );
 
-					var width = $( '.elementor-element-' + id ).closest('.elementor-section').outerWidth();
-					var sec_pos = $( '.elementor-element-' + id ).closest('.elementor-section').offset().left - $selector.offset().left;
+					var closestElement = $( '.elementor-element-' + id ).closest('.elementor-section, .e-con-boxed');
+					var width = closestElement.outerWidth();
+					var sec_pos = closestElement.offset().left - $selector.offset().left;
 				
 					$selector.css( 'width', width + 'px' );
 					$selector.css( 'left', sec_pos + 'px' );

--- a/readme.txt
+++ b/readme.txt
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.6.37.1 = 
-- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu container is set to full width.
+- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width.
 
 = 1.6.37 = 
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/readme.txt
+++ b/readme.txt
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.6.37.1 = 
-- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu is set to full width.
+- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu container is set to full width.
 
 = 1.6.37 = 
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.6.37.1 = 
+- Fix: Navigation Menu - Dropdown menu now extends to full width when the navigation menu is set to full width.
+
 = 1.6.37 = 
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.
 

--- a/readme.txt
+++ b/readme.txt
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.6.37.1 = 
-- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width.
+- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width on smaller screens.
 
 = 1.6.37 = 
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.

--- a/readme.txt
+++ b/readme.txt
@@ -141,7 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.6.37.1 = 
-- Fix: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width on smaller screens.
+- Improvement: Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width on smaller screens.
 
 = 1.6.37 = 
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.23 version.


### PR DESCRIPTION
### Description
- Navigation Menu - The dropdown menu now extends to full width when the navigation menu container is set to full width.

### Screenshots
https://prnt.sc/QS9hD-8mBIEZ

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
