### PR TITLE
Fix: Page title icon size issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
+### 1.6.41.1 ###
+- Fix: Page Title - The icon was showing too big, now it appears the right size.
+
 ### 1.6.41 ###
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.24 version.
 - Improvement: Implemented widget output caching to enhance page performance.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 ## Changelog ##
 
 ### 1.6.41.1 ###
+- Improvement: Support for Font Awesome 5 icons.
 - Fix: Page Title - The icon was showing too big, now it appears the right size.
 
 ### 1.6.41 ###

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -394,25 +394,6 @@ class Header_Footer_Elementor {
 		if ( class_exists( '\Elementor\Plugin' ) ) {
 			$elementor = \Elementor\Plugin::instance();
 			$elementor->frontend->enqueue_styles();
-
-			wp_enqueue_style(
-				'hfe-nav-menu-icons',
-				plugins_url( '/elementor/assets/lib/font-awesome/css/solid.css', 'elementor' ),
-				[],
-				'5.15.3'
-			);
-			wp_enqueue_style(
-				'hfe-icons-brands',
-				plugins_url( '/elementor/assets/lib/font-awesome/css/brands.css', 'elementor' ),
-				[],
-				'5.15.3'
-			);
-			wp_enqueue_style(
-				'hfe-icons-fontawesome',
-				plugins_url( '/elementor/assets/lib/font-awesome/css/fontawesome.css', 'elementor' ),
-				[],
-				'5.15.3'
-			);
 		}
 
 		if ( class_exists( '\ElementorPro\Plugin' ) ) {

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -394,6 +394,25 @@ class Header_Footer_Elementor {
 		if ( class_exists( '\Elementor\Plugin' ) ) {
 			$elementor = \Elementor\Plugin::instance();
 			$elementor->frontend->enqueue_styles();
+
+			wp_enqueue_style(
+				'hfe-nav-menu-icons',
+				plugins_url( '/elementor/assets/lib/font-awesome/css/solid.css', 'elementor' ),
+				[],
+				'5.15.3'
+			);
+			wp_enqueue_style(
+				'hfe-icons-brands',
+				plugins_url( '/elementor/assets/lib/font-awesome/css/brands.css', 'elementor' ),
+				[],
+				'5.15.3'
+			);
+			wp_enqueue_style(
+				'hfe-icons-fontawesome',
+				plugins_url( '/elementor/assets/lib/font-awesome/css/fontawesome.css', 'elementor' ),
+				[],
+				'5.15.3'
+			);
 		}
 
 		if ( class_exists( '\ElementorPro\Plugin' ) ) {

--- a/inc/widgets-css/frontend.css
+++ b/inc/widgets-css/frontend.css
@@ -1601,6 +1601,13 @@ div.hfe-nav-menu,
 
 .hfe-icon {
     display: inline-block;
+    vertical-align: middle; /* Alignment of icon */
+}
+
+/* Icon Svg */
+.hfe-icon svg {
+    width: 1em;
+    height: 1em;
 }
 
 /* Menu Cart CSS */

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -448,7 +448,8 @@ class Page_Title extends Widget_Base {
 			<<?php echo esc_attr( $heading_size_tag ); ?> class="elementor-heading-title elementor-size-<?php echo esc_attr( $settings['size'] ); ?>">
 				<?php if ( '' !== $settings['new_page_title_select_icon']['value'] ) { ?>
 						<span class="hfe-icon hfe-page-title-icon">
-							<?php \Elementor\Icons_Manager::render_icon( $settings['new_page_title_select_icon'], [ 'aria-hidden' => 'true' ] ); ?>             </span>
+							<?php \Elementor\Icons_Manager::render_icon( $settings['new_page_title_select_icon'], [ 'aria-hidden' => 'true' ] ); ?>
+						</span>
 				<?php } ?>				
 				<?php if ( '' !== $settings['before'] ) { ?>
 					<?php echo wp_kses_post( $settings['before'] ); ?>

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -447,7 +447,7 @@ class Page_Title extends Widget_Base {
 			<?php } ?>
 			<<?php echo esc_attr( $heading_size_tag ); ?> class="elementor-heading-title elementor-size-<?php echo esc_attr( $settings['size'] ); ?>">
 				<?php if ( '' !== $settings['new_page_title_select_icon']['value'] ) { ?>
-						<span class="hfe-page-title-icon">
+						<span class="hfe-icon hfe-page-title-icon">
 							<?php \Elementor\Icons_Manager::render_icon( $settings['new_page_title_select_icon'], [ 'aria-hidden' => 'true' ] ); ?>             </span>
 				<?php } ?>				
 				<?php if ( '' !== $settings['before'] ) { ?>
@@ -514,7 +514,7 @@ class Page_Title extends Widget_Base {
 			<# } #>
 			<{{{ headingSizeTag }}} class="elementor-heading-title elementor-size-<?php echo isset( $settings['size'] ) ? esc_attr( $settings['size'] ) : '{{{ settings.size }}}'; ?>"> <?php //phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
 				<# if( '' != settings.new_page_title_select_icon.value ){ #>
-					<span class="hfe-page-title-icon" data-elementor-setting-key="page_title" data-elementor-inline-editing-toolbar="basic">
+					<span class="hfe-icon hfe-page-title-icon" data-elementor-setting-key="page_title" data-elementor-inline-editing-toolbar="basic">
 						{{{iconHTML.value}}} <?php // PHPCS:Ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>                    
 					</span>
 				<# } #>

--- a/readme.txt
+++ b/readme.txt
@@ -141,6 +141,7 @@ This same applies when you are creating your Header/Footer using this plugin.
 == Changelog ==
 
 = 1.6.41.1 =
+- Improvement: Support for Font Awesome 5 icons.
 - Fix: Page Title - The icon was showing too big, now it appears the right size.
 
 = 1.6.41 =

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.6.41.1 =
+- Fix: Page Title - The icon was showing too big, now it appears the right size.
+
 = 1.6.41 =
 - Improvement: Compatibility with latest Elementor and Elementor Pro 3.24 version.
 - Improvement: Implemented widget output caching to enhance page performance.


### PR DESCRIPTION
### Description
https://prnt.sc/UQlh5jabUGc7
Page title icon appearing big on UI

Widget: 
Navigation Menu 
Search icon 

https://prnt.sc/ivYOaYwfg7tc

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
