### PR TITLE
EPS-874: FILTER_SANITIZE_STRING deprecated in HFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 ## Changelog ##
 
+### 1.6.45.1 ###
+- Fix: Deprecated constant FILTER_SANITIZE_STRING replaced to ensure compatibility with PHP
+
 ### 1.6.45 ###
 - Improvement: Enhanced the enqueue_scripts method with checks to ensure styles load safely.
 

--- a/admin/bsf-analytics/class-bsf-analytics-stats.php
+++ b/admin/bsf-analytics/class-bsf-analytics-stats.php
@@ -68,7 +68,7 @@ if ( ! class_exists( 'BSF_Analytics_Stats' ) ) {
 				'graupi_version'         => defined( 'BSF_UPDATER_VERSION' ) ? BSF_UPDATER_VERSION : false,
 				'domain_name'            => get_site_url(),
 				'php_os'                 => PHP_OS,
-				'server_software'        => isset( $_SERVER['SERVER_SOFTWARE'] ) ? filter_var( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ), FILTER_SANITIZE_STRING ) : '',
+				'server_software'        => isset( $_SERVER['SERVER_SOFTWARE'] ) ? filter_var( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ), FILTER_SANITIZE_SPECIAL_CHARS ) : '',
 				'mysql_version'          => $this->get_mysql_version(),
 				'php_version'            => $this->get_php_version(),
 				'php_max_input_vars'     => ini_get( 'max_input_vars' ), // phpcs:ignore:PHPCompatibility.IniDirectives.NewIniDirectives.max_input_varsFound

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,9 @@ This same applies when you are creating your Header/Footer using this plugin.
 
 == Changelog ==
 
+= 1.6.45.1 =
+- Fix: Deprecated constant FILTER_SANITIZE_STRING replaced to ensure compatibility with PHP
+
 = 1.6.45 =
 - Improvement: Enhanced the enqueue_scripts method with checks to ensure styles load safely.
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
