### PR TITLE
EPS-906: Sanitise size in Page Title

### DIFF
--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -491,6 +491,10 @@ class Page_Title extends Widget_Base {
 			return;
 		}
 
+		if ( '' == settings.size ){
+			return;
+		}
+
 		if ( '' != settings.page_heading_link.url ) {
 			var urlPattern = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$|^www\.[^\s/$.?#].[^\s]*$/;
 			if( urlPattern.test( settings.page_heading_link.url ) ){
@@ -513,7 +517,7 @@ class Page_Title extends Widget_Base {
 			<# if ( '' != settings.page_heading_link.url ) { #>
 					<a {{{ view.getRenderAttributeString( 'url' ) }}} > <?php // PHPCS:Ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
 			<# } #>
-			<{{{ headingSizeTag }}} class="elementor-heading-title elementor-size-<?php echo isset( $settings['size'] ) ? esc_attr( $settings['size'] ) : '{{{ settings.size }}}'; ?>"> <?php //phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
+			<{{{ headingSizeTag }}} class="elementor-heading-title elementor-size-<?php echo isset( $settings['size'] ) ? esc_attr( $settings['size'] ) : ''; ?>{{{ elementor.helpers.sanitize( settings.size ) }}}"> <?php //phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>	
 				<# if( '' != settings.new_page_title_select_icon.value ){ #>
 					<span class="hfe-icon hfe-page-title-icon" data-elementor-setting-key="page_title" data-elementor-inline-editing-toolbar="basic">
 						{{{iconHTML.value}}} <?php // PHPCS:Ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>                    

--- a/inc/widgets-manager/widgets/class-page-title.php
+++ b/inc/widgets-manager/widgets/class-page-title.php
@@ -517,7 +517,7 @@ class Page_Title extends Widget_Base {
 			<# if ( '' != settings.page_heading_link.url ) { #>
 					<a {{{ view.getRenderAttributeString( 'url' ) }}} > <?php // PHPCS:Ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>
 			<# } #>
-			<{{{ headingSizeTag }}} class="elementor-heading-title elementor-size-<?php echo isset( $settings['size'] ) ? esc_attr( $settings['size'] ) : ''; ?>{{{ elementor.helpers.sanitize( settings.size ) }}}"> <?php //phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>	
+			<{{{ headingSizeTag }}} class="elementor-heading-title elementor-size-{{{ elementor.helpers.sanitize( settings.size ) }}}"> <?php //phpcs:ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>	
 				<# if( '' != settings.new_page_title_select_icon.value ){ #>
 					<span class="hfe-icon hfe-page-title-icon" data-elementor-setting-key="page_title" data-elementor-inline-editing-toolbar="basic">
 						{{{iconHTML.value}}} <?php // PHPCS:Ignore WordPressVIPMinimum.Security.Mustache.OutputNotation ?>                    


### PR DESCRIPTION
### Description
This pull request includes changes to the `content_template` function in the `class-page-title.php` file to improve validation and sanitization of settings. The most important changes are as follows:

Validation improvements:

* Added a check to ensure the `settings.size` is not empty before proceeding with the function.

Sanitization improvements:

* Updated the `headingSizeTag` class attribute to use `elementor.helpers.sanitize` for the `settings.size` value, enhancing security by ensuring the size value is properly sanitized.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
