### PR TITLE
Function _load_textdomain_just_in_time was called incorrectly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 5.0    
 **Tested up to:** 6.7.1   
 **Requires PHP:** 7.4    
-**Stable tag:** 2.0.3  
+**Stable tag:** 2.0.3.1
 **License:** GPLv2 or later    
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html    
 

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -47,7 +47,7 @@ function hfe_init() {
 	Header_Footer_Elementor::instance();
 }
 
-add_action( 'init', 'hfe_init' );
+add_action( 'plugins_loaded', 'hfe_init' );
 
 /** Function for FA5, Social Icons, Icon List */
 function hfe_enqueue_font_awesome() {

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 2.0.3
+ * Version: 2.0.3.1
  * Elementor tested up to: 3.26
  * Elementor Pro tested up to: 3.26
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '2.0.3' );
+define( 'HFE_VER', '2.0.3.1' );
 define( 'HFE_FILE', __FILE__ );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -47,7 +47,7 @@ function hfe_init() {
 	Header_Footer_Elementor::instance();
 }
 
-add_action( 'plugins_loaded', 'hfe_init');
+add_action( 'plugins_loaded', 'hfe_init' );
 
 /** Function for FA5, Social Icons, Icon List */
 function hfe_enqueue_font_awesome() {

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -47,7 +47,7 @@ function hfe_init() {
 	Header_Footer_Elementor::instance();
 }
 
-add_action( 'plugins_loaded', 'hfe_init' );
+add_action( 'plugins_loaded', 'hfe_init');
 
 /** Function for FA5, Social Icons, Icon List */
 function hfe_enqueue_font_awesome() {

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -47,7 +47,7 @@ function hfe_init() {
 	Header_Footer_Elementor::instance();
 }
 
-add_action( 'plugins_loaded', 'hfe_init' );
+add_action( 'init', 'hfe_init' );
 
 /** Function for FA5, Social Icons, Icon List */
 function hfe_enqueue_font_awesome() {

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -66,7 +66,7 @@ class Header_Footer_Elementor {
 
 			$this->includes();
 			// Hook load_textdomain to the init action.
-			add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+			add_action( 'init', array( $this, 'load_textdomain' ) );
 
 			add_filter(
 				'elementor/admin-top-bar/is-active',

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -64,8 +64,8 @@ class Header_Footer_Elementor {
 		if ( $is_elementor_callable ) {
 			self::$elementor_instance = Elementor\Plugin::instance();
 
-			$this->includes();
 			// Hook load_textdomain to the init action.
+			add_action( 'init', [ $this, 'includes' ] );
 			add_action( 'init', array( $this, 'load_textdomain' ) );
 
 			add_filter(
@@ -368,6 +368,9 @@ class Header_Footer_Elementor {
 	 * @return void
 	 */
 	public function includes() {
+		// Load textdomain first
+		$this->load_textdomain();
+		
 		require_once HFE_DIR . 'admin/class-hfe-admin.php';
 
 		require_once HFE_DIR . 'inc/hfe-functions.php';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 		"name": "header-footer-elementor",
-		"version": "2.0.3",
+		"version": "2.0.3.1",
 		"main": "index.js",
 		"author": "Nikhil Chavan",
 		"volta": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: elementor, header footer builder, widgets, header template, footer templat
 Requires at least: 5.0  
 Tested up to: 6.7.1 
 Requires PHP: 7.4  
-Stable tag: 2.0.3
+Stable tag: 2.0.3.1
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
