### PR TITLE
Version 2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 5.0    
 **Tested up to:** 6.7.1   
 **Requires PHP:** 7.4    
-**Stable tag:** 2.0.5  
+**Stable tag:** 2.0.6  
 **License:** GPLv2 or later    
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html    
 
@@ -128,6 +128,9 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 ---
 
 ## Changelog ##
+
+### 2.0.6 ###
+- Fix: Load text domain PHP warning when Loco Translate plugin is active.
 
 ### 2.0.5 ###
 - Fix: Conflict with pro version update notice.

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -7,14 +7,14 @@
  * Author URI:  https://www.brainstormforce.com/
  * Text Domain: header-footer-elementor
  * Domain Path: /languages
- * Version: 2.0.5
+ * Version: 2.0.6
  * Elementor tested up to: 3.26
  * Elementor Pro tested up to: 3.26
  *
  * @package         header-footer-elementor
  */
 
-define( 'HFE_VER', '2.0.5' );
+define( 'HFE_VER', '2.0.6' );
 define( 'HFE_FILE', __FILE__ );
 define( 'HFE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'HFE_URL', plugins_url( '/', __FILE__ ) );

--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -65,7 +65,8 @@ class Header_Footer_Elementor {
 			self::$elementor_instance = Elementor\Plugin::instance();
 
 			$this->includes();
-			$this->load_textdomain();
+			
+			add_action( 'init', [ $this, 'load_textdomain' ] );
 
 			add_filter(
 				'elementor/admin-top-bar/is-active',

--- a/inc/widgets-manager/class-extensions-loader.php
+++ b/inc/widgets-manager/class-extensions-loader.php
@@ -51,8 +51,18 @@ class Extensions_Loader {
 	 */
 	private function __construct() {
 
-		$this->include_extensions_files();
+		add_action( 'elementor/init', [ $this, 'elementor_init' ] );
 
+	}
+
+	/**
+	 * Elementor Init.
+	 *
+	 * @since x.x.x
+	 */
+	public function elementor_init() {
+
+		$this->include_extensions_files();
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 		"name": "header-footer-elementor",
-		"version": "2.0.5",
+		"version": "2.0.6",
 		"main": "index.js",
 		"author": "Nikhil Chavan",
 		"volta": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: elementor, header footer builder, widgets, header template, footer templat
 Requires at least: 5.0  
 Tested up to: 6.7.1 
 Requires PHP: 7.4  
-Stable tag: 2.0.5
+Stable tag: 2.0.6
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -128,6 +128,9 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 ---
 
 == Changelog ==
+
+= 2.0.6 =
+- Fix: Load text domain PHP warning when Loco Translate plugin is active.
 
 = 2.0.5 =
 - Fix: Conflict with pro version update notice.


### PR DESCRIPTION
### Description
- Fix: Load text domain PHP warning when Loco Translate plugin is active.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
