### PR TITLE
EPS-951: UAE tag in page editor is overriding on scroll

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -29,7 +29,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 1;
+  z-index: 0;
   color: #a4afb7;
   background: transparent;
   font-size: 10px;


### PR DESCRIPTION
### Description

On scroll of page editor, the UAE tag is overriding on top.

### Screenshots
https://capture.dropbox.com/9clPgYWust3nm4T1

### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Screencast for Testcase - https://bsf.d.pr/v/ExJJEI

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
