### PR TITLE
EPS-946: Menu Widget and WP Menu not loading correctly on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 
 ## Changelog ##
 
+### 2.0.6.1 ###
+- Fix: Resolved issue where icons were displaying too large on page load for the Elementor and Wordpress menu widget.
+
 ### 2.0.6 ###
 - Fix: Load text domain PHP warning when Loco Translate plugin is active.
 

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -86,7 +86,7 @@ function hfe_enqueue_font_awesome() {
 			'5.15.3'
 		);
 	}
-	if ( class_exists( '\ElementorPro\Plugin' ) && is_plugin_active( 'elementor-pro/elementor-pro.php' ) ) {
+	if ( class_exists( '\ElementorPro\Plugin' ) ) {
 		wp_enqueue_style(
 			'hfe-widget-blockquote',
 			plugins_url( '/elementor-pro/assets/css/widget-blockquote.min.css', 'elementor' ),

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -86,7 +86,7 @@ function hfe_enqueue_font_awesome() {
 			'5.15.3'
 		);
 	}
-	if ( class_exists( '\ElementorPro\Plugin' ) ) {
+	if ( class_exists( '\ElementorPro\Plugin' ) && is_plugin_active( 'elementor-pro/elementor-pro.php' ) ) {
 		wp_enqueue_style(
 			'hfe-widget-blockquote',
 			plugins_url( '/elementor-pro/assets/css/widget-blockquote.min.css', 'elementor' ),

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -93,6 +93,18 @@ function hfe_enqueue_font_awesome() {
 			[],
 			'3.25.0'
 		);
+		wp_enqueue_style(
+			'mega-menu',
+			plugins_url( '/elementor-pro/assets/css/widget-mega-menu.min.css', 'elementor' ),
+			[],
+			'3.26.2'
+		);
+		wp_enqueue_style(
+			'nav-menu-widget',
+			plugins_url( '/elementor-pro/assets/css/widget-nav-menu.min.css', 'elementor' ),
+			[],
+			'3.26.0'
+		);
 	}
 }
 add_action( 'wp_enqueue_scripts', 'hfe_enqueue_font_awesome', 20 );

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,9 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 
 == Changelog ==
 
+= 2.0.6.1 =
+- Fix: Resolved issue where icons were displaying too large on page load for the Elementor and Wordpress menu widget.
+
 = 2.0.6 =
 - Fix: Load text domain PHP warning when Loco Translate plugin is active.
 


### PR DESCRIPTION
### Description
When adding the Elementor Pro Menu widget to the header and loading the page on the frontend, the menu briefly duplicates for a second before returning to its original state.

### Screenshots
https://bsf.d.pr/v/6M8sBo - Elementor
https://bsf.d.pr/v/DJ8s5u - WP [0:24]

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
1. Add the Elementor Pro Menu widget to the header using the EHF plugin.
2. Then added a content to the menu.
3. Load the page on the frontend.
4. Observe the brief duplication of the menu during the page load.
5. Similar add Menu widget from WordPress 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
