### PR TITLE
EPS-833: Custom cart icon not showing for incognito mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 
 ### 2.0.6.1 ###
 - Fix: Resolved issue where icons were displaying too large on page load for the Elementor and Wordpress menu widget.
+- Fix: Resolved an issue where icons were not displaying correctly for logged-out users.
 
 ### 2.0.6 ###
 - Fix: Load text domain PHP warning when Loco Translate plugin is active.

--- a/header-footer-elementor.php
+++ b/header-footer-elementor.php
@@ -53,7 +53,14 @@ add_action( 'plugins_loaded', 'hfe_init' );
 function hfe_enqueue_font_awesome() {
 
 	if ( class_exists( 'Elementor\Plugin' ) ) {
-		
+
+		// Ensure Elementor Icons CSS is loaded.
+        wp_enqueue_style(
+            'hfe-elementor-icons',
+            plugins_url( '/elementor/assets/lib/eicons/css/elementor-icons.min.css', 'elementor' ),
+            [],
+            '5.34.0'
+        );
 		wp_enqueue_style(
 			'hfe-icons-list',
 			plugins_url( '/elementor/assets/css/widget-icon-list.min.css', 'elementor' ),

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 
 = 2.0.6.1 =
 - Fix: Resolved issue where icons were displaying too large on page load for the Elementor and Wordpress menu widget.
-- Fix: Resolved an issue where icons were not displaying correctly for non-admin users.
+- Fix: Resolved an issue where icons were not displaying correctly for logged-out users.
 
 = 2.0.6 =
 - Fix: Load text domain PHP warning when Loco Translate plugin is active.

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 
 = 2.0.6.1 =
 - Fix: Resolved issue where icons were displaying too large on page load for the Elementor and Wordpress menu widget.
+- Fix: Resolved an issue where icons were not displaying correctly for non-admin users.
 
 = 2.0.6 =
 - Fix: Load text domain PHP warning when Loco Translate plugin is active.


### PR DESCRIPTION
This pull request includes a change to the `header-footer-elementor.php` file to ensure that the Elementor Icons CSS is loaded when Elementor is active.

* [`header-footer-elementor.php`](diffhunk://#diff-82ee260aaf0c8764e241ccad11db6b10d7ba6d58fdcbf940b9c402f45dff2407R57-R63): Added a call to `wp_enqueue_style` to load `elementor-icons.min.css` from the Elementor plugin's assets.### Description
<!-- Please describe what you have changed or added -->

### Screenshots
https://prnt.sc/QY4WQmB6UjWf

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?

- Add the Cart Widget from UAE using Elementor
- Select the "Type" as "Custom" from the dropdown
- Check the Frontend on Incognito Mode and check if the cart icon is displayed properly. as per the screenshots

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
