### PR TITLE
EPS- 1012: Navigation issue in  full width

### DIFF
--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -155,6 +155,14 @@
 				}else if ( window.matchMedia( "( max-width: 1024px )" ).matches && $( '.elementor-element-' + id ).hasClass('hfe-nav-menu__breakpoint-tablet') ) {
 					
 					_toggleClick( id );
+				}else{
+					var $toggle = $( '.elementor-element-' + id + ' .hfe-nav-menu__toggle' );
+                    var $nextElement= $toggle.next();
+                    var width = $nextElement.parent().width();
+                    if( $nextElement.length ){
+						$nextElement.css( 'width', width + 'px' );
+						$nextElement.css( 'left', '0' );
+					}
 				}
 			}
 
@@ -585,7 +593,7 @@
 			if( $nextElement.length ){
 				$nextElement.css( 'left', '0' );
 				
-				var $section = $( '.elementor-element-' + id ).closest('.elementor-section');
+				var $section = $( '.elementor-element-' + id ).closest('.elementor-section, .e-con-boxed');
 				if ( $section.length ) {
 					var width = $section.outerWidth();
 					var sec_pos = $section.offset().left - $toggle.next().offset().left;

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,9 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 
 == Changelog ==
 
+= 2.2.0.1 =
+- Fix: Navigation Menu -  Full width option in hamburger menu works correctly while resizing the screen.
+
 = 2.2.0 =
 - New: Ultimate Addons for Elementor now includes translations for Dutch, French, Spanish, and German enhancing multilingual accessibility.
 - Fix: Navigation Menu - Anchor links now correctly scroll to sections/container when submenu items with IDs are clicked.

--- a/readme.txt
+++ b/readme.txt
@@ -130,7 +130,7 @@ To access the advanced features and premium widgets, you’ll need to upgrade to
 == Changelog ==
 
 = 2.2.0.1 =
-- Fix: Navigation Menu -  Full width option in hamburger menu works correctly while resizing the screen.
+- Fix: Navigation Menu - Full-width dropdown menu now stays correctly positioned when resizing in responsive mode.
 
 = 2.2.0 =
 - New: Ultimate Addons for Elementor now includes translations for Dutch, French, Spanish, and German enhancing multilingual accessibility.


### PR DESCRIPTION
### Description
Main Purpose: This pull request fixes the navigation menu issue with full width.


### Screenshots
Video Link - https://www.awesomescreenshot.com/video/36062563?key=5170b681f28f481b50761e0c06da96c5

### Types of changes

- Added a class '.e-con-boxed' to fetch the top element. So, it will be in full width while resizing.
- I added code to fix the width and left position when it come back to the normal position.

### How has this been tested?

- Check the Navigation Menu It should be working in all four layouts.
- When in a horizontal and vertical layout and the full-width feature is on then when you resize the window on front page it should show the menu in full width.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
