### PR TITLE
Added flush permalink button to the Elementor editor notice

### DIFF
--- a/admin/class-hfe-addons-actions.php
+++ b/admin/class-hfe-addons-actions.php
@@ -115,6 +115,9 @@ if ( ! class_exists( 'HFE_Addons_Actions' ) ) {
 			{ 
 				update_option('permalink_structure', get_option('permalink_structure'));
 				flush_rewrite_rules(); 
+				// Update the option to true.
+				update_user_meta( get_current_user_id(), 'hfe_permalink_notice_option', 'notice-dismissed' );
+		
 			} 
 
 			// Send a success response.

--- a/admin/class-hfe-addons-actions.php
+++ b/admin/class-hfe-addons-actions.php
@@ -111,9 +111,11 @@ if ( ! class_exists( 'HFE_Addons_Actions' ) ) {
 				wp_send_json_error( 'Unauthorized user' );
 			}
 
-			if (get_option('permalink_structure') != '') 
+			$permalink_structure = get_option('permalink_structure');
+			// Check if the permalink structure is not empty.
+			if ( $permalink_structure != '' ) 
 			{ 
-				update_option('permalink_structure', get_option('permalink_structure'));
+				update_option('permalink_structure', $permalink_structure);
 				flush_rewrite_rules(); 
 				// Update the option to true.
 				update_user_meta( get_current_user_id(), 'hfe_permalink_notice_option', 'notice-dismissed' );

--- a/admin/class-hfe-addons-actions.php
+++ b/admin/class-hfe-addons-actions.php
@@ -67,6 +67,8 @@ if ( ! class_exists( 'HFE_Addons_Actions' ) ) {
 
 			add_action( 'wp_ajax_update_permalink_notice_option', [ $this, 'update_permalink_notice_option' ] );
 			add_action( 'wp_ajax_nopriv_update_permalink_notice_option', [ $this, 'update_permalink_notice_option' ] );
+			add_action( 'wp_ajax_hfe_flush_permalink_notice', [ $this, 'hfe_flush_permalink_notice' ] );
+			add_action( 'wp_ajax_nopriv_hfe_flush_permalink_notice', [ $this, 'hfe_flush_permalink_notice' ] );
 
 		}
 
@@ -91,6 +93,32 @@ if ( ! class_exists( 'HFE_Addons_Actions' ) ) {
 		
 			// Send a success response.
 			wp_send_json_success( 'Option updated successfully' );
+		}
+
+		/**
+		 * Updated the permalink notice option.
+		 *
+		 * @since 2.2.1
+		 */
+		public function hfe_flush_permalink_notice() {
+			// Verify the nonce.
+			if ( ! isset( $_POST['nonce'] ) || ! check_ajax_referer( 'hfe_permalink_clear_notice_nonce', 'nonce', false ) ) {
+				wp_send_json_error( 'Invalid nonce' );
+			}
+			
+			// Check if the current user has the capability to manage options.
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error( 'Unauthorized user' );
+			}
+
+			if (get_option('permalink_structure') != '') 
+			{ 
+				update_option('permalink_structure', get_option('permalink_structure'));
+				flush_rewrite_rules(); 
+			} 
+
+			// Send a success response.
+			wp_send_json_success( 'Permalink Flushed successfully' );
 		}
 		
 		/**

--- a/admin/class-hfe-addons-actions.php
+++ b/admin/class-hfe-addons-actions.php
@@ -113,7 +113,7 @@ if ( ! class_exists( 'HFE_Addons_Actions' ) ) {
 
 			$permalink_structure = get_option('permalink_structure');
 			// Check if the permalink structure is not empty.
-			if ( $permalink_structure != '' ) 
+			if ( '' !== $permalink_structure )
 			{ 
 				update_option('permalink_structure', $permalink_structure);
 				flush_rewrite_rules(); 

--- a/admin/class-hfe-admin.php
+++ b/admin/class-hfe-admin.php
@@ -194,7 +194,7 @@ class HFE_Admin {
 			<header>
 				<i class="eicon-warning"></i>
 				<h2><?php echo esc_html__( 'Important Notice:', 'header-footer-elementor' ); ?></h2>
-				<button class="uae_permalink-notice-close"><i class="eicon-close"></i></button>
+				<button class="uae-permalink-notice-close"><i class="eicon-close"></i></button>
 			</header>
 			<div class="uae-permalink-notice-content">
 				<b><?php echo esc_html__( 'Can\'t edit your header or footer?', 'header-footer-elementor' ); ?></b><br/>
@@ -202,7 +202,10 @@ class HFE_Admin {
 				<a href="<?php echo esc_url( 'https://ultimateelementor.com/docs/elementor-header-footer-template-not-loading-or-stuck-on-loading/' ); ?>" target="_blank"><?php echo esc_html_e( 'Learn More', 'header-footer-elementor' ); ?></a>
 				<br>
 				<?php if(!is_multisite()){ ?>
-					<button class="uae_permalink-flush-btn"><span class="uae-btn-main-text">Flush Permalink</span><span class="uae-notice-loader"></span></button>
+					<button class="uae-permalink-flush-btn" type="button">
+						<span class="uae-btn-main-text">Flush Permalink</span>
+						<span class="uae-notice-loader"></span>
+					</button>
 				<?php } ?>
 			</div>
 		<?php } ?>

--- a/admin/class-hfe-admin.php
+++ b/admin/class-hfe-admin.php
@@ -200,6 +200,8 @@ class HFE_Admin {
 				<b><?php echo esc_html__( 'Can\'t edit your header or footer?', 'header-footer-elementor' ); ?></b><br/>
 				<?php echo esc_html__( 'Try clearing your cache or resetting permalinks (Settings > Permalinks > Save Changes).', 'header-footer-elementor' ); ?>
 				<a href="<?php echo esc_url( 'https://ultimateelementor.com/docs/elementor-header-footer-template-not-loading-or-stuck-on-loading/' ); ?>" target="_blank"><?php echo esc_html_e( 'Learn More', 'header-footer-elementor' ); ?></a>
+				<br>
+				<button class="uae_permalink-flush-btn"><b>Flush Permalink</b></button>
 			</div>
 		<?php } ?>
 	</div>

--- a/admin/class-hfe-admin.php
+++ b/admin/class-hfe-admin.php
@@ -201,8 +201,9 @@ class HFE_Admin {
 				<?php echo esc_html__( 'Try clearing your cache or resetting permalinks (Settings > Permalinks > Save Changes).', 'header-footer-elementor' ); ?>
 				<a href="<?php echo esc_url( 'https://ultimateelementor.com/docs/elementor-header-footer-template-not-loading-or-stuck-on-loading/' ); ?>" target="_blank"><?php echo esc_html_e( 'Learn More', 'header-footer-elementor' ); ?></a>
 				<br>
-				
-				<button class="uae_permalink-flush-btn"><span class="uae-btn-main-text">Flush Permalink</span><span class="uae-notice-loader"></span></button>
+				<?php if(!is_multisite()){ ?>
+					<button class="uae_permalink-flush-btn"><span class="uae-btn-main-text">Flush Permalink</span><span class="uae-notice-loader"></span></button>
+				<?php } ?>
 			</div>
 		<?php } ?>
 	</div>

--- a/admin/class-hfe-admin.php
+++ b/admin/class-hfe-admin.php
@@ -201,7 +201,8 @@ class HFE_Admin {
 				<?php echo esc_html__( 'Try clearing your cache or resetting permalinks (Settings > Permalinks > Save Changes).', 'header-footer-elementor' ); ?>
 				<a href="<?php echo esc_url( 'https://ultimateelementor.com/docs/elementor-header-footer-template-not-loading-or-stuck-on-loading/' ); ?>" target="_blank"><?php echo esc_html_e( 'Learn More', 'header-footer-elementor' ); ?></a>
 				<br>
-				<button class="uae_permalink-flush-btn"><b>Flush Permalink</b></button>
+				
+				<button class="uae_permalink-flush-btn"><span class="uae-btn-main-text">Flush Permalink</span><span class="uae-notice-loader"></span></button>
 			</div>
 		<?php } ?>
 	</div>

--- a/inc/js/permalink-clear-notice.js
+++ b/inc/js/permalink-clear-notice.js
@@ -27,6 +27,32 @@ var ElementorEditorCheck = function() {
         });
     }
 
+    var isPermalinkFlushed = function() {
+
+        jQuery(document).on('click', '.uae_permalink-flush-btn', function(e) {
+                jQuery.ajax({
+                    url: hfePermalinkClearNotice.ajaxurl,
+                    type: 'POST',
+                    data: {
+                        action: 'hfe_flush_permalink_notice',
+                        nonce: hfePermalinkClearNotice.nonce,
+                    },
+                    success: function(response) {
+                        if (response.success) {
+                            console.log('Refresh Permalink successfully');
+                            location.reload(true);
+                        } else {
+                            console.log('Error updating option: ' + response.data);
+                        }
+                    },
+                    error: function(error) {
+                        console.log('Error updating option');
+                    }
+                });
+            });
+    }
+
+
     var isElementorLoadedCheck = function() {
         if ( 'undefined' === typeof elementor ) {
             return false;
@@ -62,6 +88,7 @@ var ElementorEditorCheck = function() {
     var init = function() {
         setTimeout( permalinkNoticeCheck, 30000 );
         isNoticeClosed();
+        isPermalinkFlushed();
     };
 
     init();

--- a/inc/js/permalink-clear-notice.js
+++ b/inc/js/permalink-clear-notice.js
@@ -1,7 +1,7 @@
 var ElementorEditorCheck = function() {
     var isNoticeClosed = function() {
 
-        jQuery(document).on('click', '.uae_permalink-notice-close', function(e) {
+        jQuery(document).on('click', '.uae-permalink-notice-close', function(e) {
             var $notice = jQuery('#uae-permalink-clear-notice');
             if ($notice.data('visible')) {
                 $notice.remove();
@@ -29,11 +29,11 @@ var ElementorEditorCheck = function() {
 
     var isPermalinkFlushed = function() {
 
-        jQuery(document).on('click', '.uae_permalink-flush-btn', function(e) {
+        jQuery(document).on('click', '.uae-permalink-flush-btn', function(e) {
             
             var $loader = jQuery('.uae-notice-loader');
             var $button = jQuery(this);
-            var $buttonText = jQuery(this).find('.uae-btn-main-text');
+            var $buttonText = $button.find('.uae-btn-main-text');
 
             // Show loader and disable button
             $loader.show();
@@ -52,7 +52,7 @@ var ElementorEditorCheck = function() {
                         $loader.hide();
                         $buttonText.text('Flushed Permalink');
                         if (response.success) {
-                            console.log('Refresh Permalink successfully');
+                            console.log('Permalink refreshed successfully');
                             location.reload(true);
                         } else {
                             console.log('Error updating option: ' + response.data);

--- a/inc/js/permalink-clear-notice.js
+++ b/inc/js/permalink-clear-notice.js
@@ -30,7 +30,17 @@ var ElementorEditorCheck = function() {
     var isPermalinkFlushed = function() {
 
         jQuery(document).on('click', '.uae_permalink-flush-btn', function(e) {
-                jQuery.ajax({
+            
+            var $loader = jQuery('.uae-notice-loader');
+            var $button = jQuery(this);
+            var $buttonText = jQuery(this).find('.uae-btn-main-text');
+
+            // Show loader and disable button
+            $loader.show();
+            $buttonText.text('Flushing...');
+            $button.prop('disabled', true);
+            
+            jQuery.ajax({
                     url: hfePermalinkClearNotice.ajaxurl,
                     type: 'POST',
                     data: {
@@ -38,6 +48,9 @@ var ElementorEditorCheck = function() {
                         nonce: hfePermalinkClearNotice.nonce,
                     },
                     success: function(response) {
+                        // Hide the loader
+                        $loader.hide();
+                        $buttonText.text('Flushed Permalink');
                         if (response.success) {
                             console.log('Refresh Permalink successfully');
                             location.reload(true);
@@ -46,6 +59,9 @@ var ElementorEditorCheck = function() {
                         }
                     },
                     error: function(error) {
+                         // Hide the loader
+                        $loader.hide();
+                        $buttonText.text('Flushed Permalink');
                         console.log('Error updating option');
                     }
                 });

--- a/inc/widgets-css/permalink-clear-notice.css
+++ b/inc/widgets-css/permalink-clear-notice.css
@@ -80,7 +80,7 @@ body:not(.rtl) .uae-permalink-clear-notice {
     font-weight: 500;
     border: none;
     border-radius: 3px;
-    padding: 8px 16px;
+    padding: 16px 16px;
     margin-top: 10px;
     cursor: pointer;
 }
@@ -88,4 +88,30 @@ body:not(.rtl) .uae-permalink-clear-notice {
 .uae_permalink-flush-btn:hover {
     background-color: var(--e-a-btn-bg-primary-hover);
     color: var(--e-a-btn-color);
+}
+
+.uae-notice-loader {
+    display: none;
+}
+
+/* Add a small spinning animation inside notice */
+.uae-notice-loader::after {
+    content: "";
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin-left: 8px;
+    border: 2px solid #000;
+    border-top: 2px solid transparent;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.uae-btn-main-text{
+    font-weight: bold;
 }

--- a/inc/widgets-css/permalink-clear-notice.css
+++ b/inc/widgets-css/permalink-clear-notice.css
@@ -73,7 +73,7 @@ body:not(.rtl) .uae-permalink-clear-notice {
     font-size: 18px;
 }
 
-.uae_permalink-flush-btn{
+.uae-permalink-flush-btn{
     background-color: var(--e-a-btn-bg-primary);
     color: #000;
     font-size: 12px;
@@ -85,7 +85,7 @@ body:not(.rtl) .uae-permalink-clear-notice {
     cursor: pointer;
 }
 
-.uae_permalink-flush-btn:hover {
+.uae-permalink-flush-btn:hover {
     background-color: var(--e-a-btn-bg-primary-hover);
     color: var(--e-a-btn-color);
 }

--- a/inc/widgets-css/permalink-clear-notice.css
+++ b/inc/widgets-css/permalink-clear-notice.css
@@ -61,6 +61,7 @@ body:not(.rtl) .uae-permalink-clear-notice {
     top: 12px;
     right: 2px;
     z-index: 9999;
+    cursor: pointer;
 }
 
 .uae-permalink-clear-notice header i {
@@ -70,4 +71,21 @@ body:not(.rtl) .uae-permalink-clear-notice {
 .uae-permalink-clear-notice header h2 {
     flex-grow: 1;
     font-size: 18px;
+}
+
+.uae_permalink-flush-btn{
+    background-color: var(--e-a-btn-bg-primary);
+    color: #000;
+    font-size: 12px;
+    font-weight: 500;
+    border: none;
+    border-radius: 3px;
+    padding: 8px 16px;
+    margin-top: 10px;
+    cursor: pointer;
+}
+
+.uae_permalink-flush-btn:hover {
+    background-color: var(--e-a-btn-bg-primary-hover);
+    color: var(--e-a-btn-color);
 }


### PR DESCRIPTION
### Description
The main goal for this PR is to add a Flush Permalink button to our editor notice. That will directly flush out the permalink and reload the editor making the user experience smoother.

### Screenshots
<!-- if applicable -->
https://tinyurl.com/288znyke

### Types of changes
- Added button with Flush Permalink text.
- Create an Ajax call on button click, the function flush_rewrite_rules() is called to refresh the permalinks.
- Once the Ajax request is completed it will reload the editor so the editor will load on the user end and it start working without going to a different location to flush permalinks.


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
