### PR TITLE
Nav menu full width option now works with full width container

### DIFF
--- a/inc/js/frontend.js
+++ b/inc/js/frontend.js
@@ -593,7 +593,7 @@
 			if( $nextElement.length ){
 				$nextElement.css( 'left', '0' );
 				
-				var $section = $( '.elementor-element-' + id ).closest('.elementor-section, .e-con-boxed');
+				var $section = $( '.elementor-element-' + id ).closest('.elementor-section, .e-con-boxed, .e-con-full');
 				if ( $section.length ) {
 					var width = $section.outerWidth();
 					var sec_pos = $section.offset().left - $toggle.next().offset().left;
@@ -642,7 +642,7 @@
 
 					$this.addClass( 'hfe-active-menu-full-width' );
 
-					var closestElement = $( '.elementor-element-' + id ).closest('.elementor-section, .e-con-boxed');
+					var closestElement = $( '.elementor-element-' + id ).closest('.elementor-section, .e-con-boxed, .e-con-full');
 					var width = closestElement.outerWidth();
 					var sec_pos = closestElement.offset().left - $selector.offset().left;
 				


### PR DESCRIPTION
Added support for the nav menu full width to get it fixed when used in a full-width container.

### Description
[BSF-PR-SUMMARY]

### Screenshots
https://d.pr/v/UHr0iS

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
Steps to Reproduce:
- Create a header layout.
- Use a full-width container.
- Add widgets such as:
    - Site Title
    -  Navigation Menu (ensure the Full-Width option is enabled).
- View the page in responsive mode.
- Click on the toggle button to open the mobile menu.

Expected Result:
    The navigation menu and sub-menu should display properly, spanning the full width without errors.

Actual Result in previous version:
   - Console error appears.
   - Sub-menu does not expand to full width as expected.

Additional Checks:
 - Works fine with Boxed Width containers.
 - Works fine in Elementor Sections.
 - Works fine when Full-Width option is turned off.

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
