### PR TITLE
EPS-1182: Prioritise Astra menu after dashboard menu

### DIFF
--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -129,6 +129,8 @@ class Header_Footer_Elementor {
 				add_action( 'admin_init', [ $this, 'get_plugin_version' ] );
 			}
 
+			// Filter to change Astra menu positon.
+			add_filter( 'astra_menu_priority', array( $this, 'update_admin_menu_position' ) );
 			// Scripts and styles.
 			add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 
@@ -171,6 +173,15 @@ class Header_Footer_Elementor {
 				]
 			);   
 		}
+	}
+
+	/**
+	 * Update Astra's menu priority to show after Dashboard menu.
+	 *
+	 * @param int $menu_priority top level menu priority.
+	 */
+	public function update_admin_menu_position( $menu_priority ) {
+		return 2.1;
 	}
 
 	/**


### PR DESCRIPTION
### Description
This PR adds a code snippet to the plugin that ensures the Astra menu appears immediately after the Dashboard menu in the WordPress admin panel.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
