### PR TITLE
EPS-1258: Adding notice in infocard widget to promote infobox

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -238,3 +238,10 @@
 .hfe-icon-shape-divider:before {
   content: "\e92b";
 }
+.elementor-control-pro_promotion_notice a {
+  color: #2463eb;
+}
+
+.elementor-control-pro_promotion_notice a:hover {
+  color: #2463eb;
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -238,10 +238,10 @@
 .hfe-icon-shape-divider:before {
   content: "\e92b";
 }
-.elementor-control-pro_promotion_notice a {
+.elementor-control-uae_pro_promotion_notice a {
   color: #2463eb;
 }
 
-.elementor-control-pro_promotion_notice a:hover {
+.elementor-control-uae_pro_promotion_notice a:hover {
   color: #2463eb;
 }

--- a/inc/widgets-manager/widgets/infocard/infocard.php
+++ b/inc/widgets-manager/widgets/infocard/infocard.php
@@ -805,8 +805,8 @@ class Infocard extends Common_Widget {
 				'type' => \Elementor\Controls_Manager::NOTICE,
 				'notice_type' => 'info',
 				'dismissible' => false,
-				'heading' => esc_html__( 'Need Advanced Styling?', 'textdomain' ),
-				'content' => __( 'Take your designs to the next level with the InfoBox widget in <a href="https://ultimateelementor.com/widgets/info-box/" _target="blank"> Pro  </a> — offering powerful styling options and enhanced flexibility.', 'textdomain' ),
+				'heading' => esc_html__( 'Need Advanced Styling?', 'header-footer-elementor' ),
+				'content' => __( 'Take your designs to the next level with the InfoBox widget in <a href="https://ultimateelementor.com/widgets/info-box/" _target="blank"> Pro  </a> — offering powerful styling options and enhanced flexibility.', 'header-footer-elementor' ),
 			]
 		);
 

--- a/inc/widgets-manager/widgets/infocard/infocard.php
+++ b/inc/widgets-manager/widgets/infocard/infocard.php
@@ -795,14 +795,14 @@ class Infocard extends Common_Widget {
 
 		if(! defined( 'UAEL_VER' )){
 			$this->start_controls_section(
-				'section_pro_field',
+				'section_pro_features_field',
 				array(
 					'label' => __( 'Pro Features', 'header-footer-elementor' ),
 				)
 			);
 			
 			$this->add_control(
-				'pro_promotion_notice',
+				'uae_pro_promotion_notice',
 				[
 					'type' => Controls_Manager::NOTICE,
 					'notice_type' => 'info',

--- a/inc/widgets-manager/widgets/infocard/infocard.php
+++ b/inc/widgets-manager/widgets/infocard/infocard.php
@@ -98,6 +98,7 @@ class Infocard extends Common_Widget {
 		$this->register_general_content_controls();
 		$this->register_icon_content_controls();
 		$this->register_cta_content_controls();
+		$this->register_pro_promotion_controls();
 		$this->register_typo_content_controls();
 		$this->register_margin_content_controls();
 	}
@@ -780,6 +781,34 @@ class Infocard extends Common_Widget {
 			$this->end_controls_tab();
 
 		$this->end_controls_tabs();
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Register Infocard General Controls.
+	 *
+	 * @since 2.3.0
+	 * @access protected
+	 */
+	protected function register_pro_promotion_controls() {
+		$this->start_controls_section(
+			'section_pro_field',
+			array(
+				'label' => __( 'Pro Features', 'header-footer-elementor' ),
+			)
+		);
+
+		$this->add_control(
+			'pro_promotion_notice',
+			[
+				'type' => \Elementor\Controls_Manager::NOTICE,
+				'notice_type' => 'info',
+				'dismissible' => false,
+				'heading' => esc_html__( 'Need Advanced Styling?', 'textdomain' ),
+				'content' => __( 'Take your designs to the next level with the InfoBox widget in <a href="https://ultimateelementor.com/widgets/info-box/" _target="blank"> Pro  </a> — offering powerful styling options and enhanced flexibility.', 'textdomain' ),
+			]
+		);
 
 		$this->end_controls_section();
 	}

--- a/inc/widgets-manager/widgets/infocard/infocard.php
+++ b/inc/widgets-manager/widgets/infocard/infocard.php
@@ -786,31 +786,35 @@ class Infocard extends Common_Widget {
 	}
 
 	/**
-	 * Register Infocard General Controls.
+	 * Register Infocard Promotion Controls.
 	 *
-	 * @since 2.3.0
+	 * @since x.x.x
 	 * @access protected
 	 */
 	protected function register_pro_promotion_controls() {
-		$this->start_controls_section(
-			'section_pro_field',
-			array(
-				'label' => __( 'Pro Features', 'header-footer-elementor' ),
-			)
-		);
 
-		$this->add_control(
-			'pro_promotion_notice',
-			[
-				'type' => \Elementor\Controls_Manager::NOTICE,
-				'notice_type' => 'info',
-				'dismissible' => false,
-				'heading' => esc_html__( 'Need Advanced Styling?', 'header-footer-elementor' ),
-				'content' => __( 'Take your designs to the next level with the InfoBox widget in <a href="https://ultimateelementor.com/widgets/info-box/" _target="blank"> Pro  </a> — offering powerful styling options and enhanced flexibility.', 'header-footer-elementor' ),
-			]
-		);
+		if(! defined( 'UAEL_VER' )){
+			$this->start_controls_section(
+				'section_pro_field',
+				array(
+					'label' => __( 'Pro Features', 'header-footer-elementor' ),
+				)
+			);
+			
+			$this->add_control(
+				'pro_promotion_notice',
+				[
+					'type' => Controls_Manager::NOTICE,
+					'notice_type' => 'info',
+					'dismissible' => false,
+					'heading' => esc_html__( 'Need Advanced Styling?', 'header-footer-elementor' ),
+					'content' => __( 'Take your designs to the next level with the InfoBox widget in <a href="https://ultimateelementor.com/widgets/info-box/?utm_source=uae-dashboard&utm_medium=editor&utm_campaign=uae-pro-promotion" target="_blank"> Pro  </a> — offering powerful styling options and enhanced flexibility.', 'header-footer-elementor' ),
+				]
+			);
+		
 
-		$this->end_controls_section();
+			$this->end_controls_section();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Description
Adding notice in infocard widget to promote infobox using Elementor notice control. Added link for infobox widget demo page.


### Screenshots
https://d.pr/i/KBmqE3

### Types of changes
- Added new section under the content tab of the widget.
- The Pro Feature section contains a notice to promote the Info Box widget.
- Check the link for info box demo page.
Check if pro plugin is added the notice should not appear.

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
