### PR TITLE
Add promotion widget build setup

### DIFF
--- a/admin/class-hfe-admin.php
+++ b/admin/class-hfe-admin.php
@@ -128,13 +128,13 @@ class HFE_Admin {
 	 * Enqueuing Promotion widget scripts.
 	 */
 	public function enqueue_editor_scripts() {
-		wp_enqueue_script(
-			'uae-pro-promotion',
-			HFE_URL . 'assets/js/promotion-widget.js',
-			['jquery'],
-			HFE_VER,
-			true
-		);
+               wp_enqueue_script(
+                       'uae-pro-promotion',
+                       HFE_URL . 'build/promotion-widget.js',
+                       ['jquery'],
+                       HFE_VER,
+                       true
+               );
 	}
 	
 	/**

--- a/src/promotion-widget.js
+++ b/src/promotion-widget.js
@@ -1,0 +1,52 @@
+// Script to override Elementor promotion dialog for HFE widgets
+(function() {
+    const initProWidgets = () => {
+        if (typeof parent.document === 'undefined') {
+            return false;
+        }
+        parent.document.addEventListener('mousedown', (e) => {
+            const proWidgets = parent.document.querySelectorAll('#elementor-panel-category-hfe-widgets .elementor-element--promotion');
+            if (proWidgets.length === 0) {
+                return;
+            }
+
+            for (let i = 0; i < proWidgets.length; i++) {
+                if (!proWidgets[i].contains(e.target)) {
+                    continue;
+                }
+
+                const dialog = parent.document.querySelector('#elementor-element--promotion__dialog');
+                const icon = proWidgets[i].querySelector('.icon > i');
+
+                if (icon.classList.toString().indexOf('hfe') >= 0) {
+                    dialog.querySelector('.dialog-buttons-action').style.display = 'none';
+                    e.stopImmediatePropagation();
+
+                    if (dialog.querySelector('.uae-upgrade-button') === null) {
+                        const button = document.createElement('a');
+                        button.appendChild(document.createTextNode('Upgrade to Pro'));
+                        button.setAttribute('href', 'https://your-upgrade-url.com');
+                        button.setAttribute('target', '_blank');
+                        button.classList.add('dialog-button', 'dialog-action', 'dialog-buttons-action', 'elementor-button', 'go-pro', 'elementor-button-success', 'your-plugin-upgrade-button');
+                        dialog.querySelector('.dialog-buttons-action').insertAdjacentHTML('afterend', button.outerHTML);
+                    } else {
+                        dialog.querySelector('.uae-upgrade-button').style.display = '';
+                    }
+                } else {
+                    dialog.querySelector('.dialog-buttons-action').style.display = '';
+                    const btn = dialog.querySelector('.your-plugin-upgrade-button');
+                    if (btn !== null) {
+                        btn.style.display = 'none';
+                    }
+                }
+                break;
+            }
+        });
+    };
+
+    if (window.elementor) {
+        elementor.on('preview:loaded', initProWidgets);
+    } else {
+        window.addEventListener('elementor/frontend/init', initProWidgets);
+    }
+})();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,16 +8,19 @@ module.exports = {
 	// Spread the default WordPress Webpack config and extend it
 	...defaultConfig,
 
-	// Define your custom entry point
-	entry: './src/index.js',
+       // Define custom entry points
+       entry: {
+               main: './src/index.js',
+               'promotion-widget': './src/promotion-widget.js',
+       },
 
 	// Customize the output
-	output: {
-		...defaultConfig.output,
-		filename: 'main.js', // Output the JS file
-		path: path.resolve(__dirname, 'build'),
-		publicPath: '/', // Set for dev server
-	},
+       output: {
+               ...defaultConfig.output,
+               filename: '[name].js', // Output file per entry
+               path: path.resolve(__dirname, 'build'),
+               publicPath: '/', // Set for dev server
+       },
 
 	// Add or extend module rules
 	module: {


### PR DESCRIPTION
## Summary
- handle promotion widget script in webpack
- enqueue built script in admin

## Testing
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_685941b50398832099d428fa2bb27603