### PR TITLE
Improve onboarding layout

### DIFF
--- a/src/Components/Onboarding/Onboarding.jsx
+++ b/src/Components/Onboarding/Onboarding.jsx
@@ -1,7 +1,16 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import OB from './index'
 
 const Onboarding = () => {
+    useEffect(() => {
+        const body = document.body
+        body.classList.add('hfe-onboarding-fullscreen')
+
+        return () => {
+            body.classList.remove('hfe-onboarding-fullscreen')
+        }
+    }, [])
+
     return (
         <>
         <OB />

--- a/src/styles.css
+++ b/src/styles.css
@@ -284,8 +284,23 @@ div#hfe-settings-app {
 		overflow: scroll;
 		max-width: fit-content;
 	}
-	.hfe-onboarding-bottom {
-		display: grid !important;
-		max-width: fit-content;
-	}
+        .hfe-onboarding-bottom {
+                display: grid !important;
+                max-width: fit-content;
+        }
+}
+
+body.hfe-onboarding-fullscreen #wpadminbar,
+body.hfe-onboarding-fullscreen #adminmenuback,
+body.hfe-onboarding-fullscreen #adminmenuwrap,
+body.hfe-onboarding-fullscreen #adminmenu,
+body.hfe-onboarding-fullscreen #wpfooter {
+       display: none;
+}
+body.hfe-onboarding-fullscreen #wpcontent {
+       margin-left: 0;
+       padding-left: 0;
+}
+body.hfe-onboarding-fullscreen.admin-bar {
+       margin-top: 0 !important;
 }


### PR DESCRIPTION
## Summary
- add a body class during onboarding to allow fullscreen display
- hide WP admin bars and side menu when onboarding is active

## Testing
- `npm run build` *(fails: `wp-scripts: not found`)*
- `npm run lint:js` *(fails: `wp-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685e153229988330b4ada619b12e7484