### PR TITLE
EPS-1666: Removed capability check in template file

### DIFF
--- a/inc/widgets-manager/widgets/basic-posts/template.php
+++ b/inc/widgets-manager/widgets/basic-posts/template.php
@@ -25,10 +25,6 @@ $title_tag = Widgets_Loader::validate_html_tag( $settings['title_tag'] ?? 'h3' )
 	while ( $this->query->have_posts() ) :
 		$this->query->the_post();
 		
-		// Security check - ensure we can read this post
-		if ( ! current_user_can( 'read_post', get_the_ID() ) ) {
-			continue;
-		}
 		?>
 		<article class="hfe-post-card">
 			<?php if ( 'yes' === $settings['show_image'] && has_post_thumbnail() ) : ?>

--- a/readme.txt
+++ b/readme.txt
@@ -299,6 +299,9 @@ You can report the issue through our [Bug Bounty Program](https://brainstormforc
 ---
 
 == Changelog ==
+= 2.5.1.1 - Development Version=
+- Fix: Basic Post Widget not showing for logged out users.
+
 = 2.5.1 =
 - Improvement: Updated required packages to the latest stable versions for improved compatibility and security.
 


### PR DESCRIPTION
### Description
**Main Purpose**: This pull request removes the capability check for reading a post within the basic posts widget template, streamlining user access to posts in the interface.

**Key Changes**:
- The security check code block that ensured the current user had permission to read the post (`current_user_can( 'read_post', get_the_ID() )`) has been removed from `template.php`.
  
**Additional Notes**: 
- By eliminating this check, users will no longer be restricted from viewing posts they do not have explicit access rights to, which could impact the visibility of content based on user roles. Reviewers should consider the security implications this might have on user data access and ensure that this aligns with the overall design goals of the user interface.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
